### PR TITLE
Fix d3d12 warning when buffer is created

### DIFF
--- a/src/FlyCube/CommandList/DXCommandList.cpp
+++ b/src/FlyCube/CommandList/DXCommandList.cpp
@@ -723,13 +723,13 @@ void DXCommandList::ResolveQueryData(const std::shared_ptr<QueryHeap>& query_hea
     decltype(auto) dx_query_heap = query_heap->As<DXRayTracingQueryHeap>();
     decltype(auto) dx_dst_buffer = dst_buffer->As<DXResource>();
     m_command_list->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(dx_query_heap.GetResource().Get(),
-                                                                             D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+                                                                             D3D12_RESOURCE_STATE_COMMON,
                                                                              D3D12_RESOURCE_STATE_COPY_SOURCE, 0));
     m_command_list->CopyBufferRegion(dx_dst_buffer.resource.Get(), dst_offset, dx_query_heap.GetResource().Get(),
                                      first_query * sizeof(uint64_t), query_count * sizeof(uint64_t));
     m_command_list->ResourceBarrier(
         1, &CD3DX12_RESOURCE_BARRIER::Transition(dx_query_heap.GetResource().Get(), D3D12_RESOURCE_STATE_COPY_SOURCE,
-                                                 D3D12_RESOURCE_STATE_UNORDERED_ACCESS, 0));
+                                                 D3D12_RESOURCE_STATE_COMMON, 0));
 }
 
 ComPtr<ID3D12GraphicsCommandList> DXCommandList::GetCommandList()

--- a/src/FlyCube/QueryHeap/DXRayTracingQueryHeap.cpp
+++ b/src/FlyCube/QueryHeap/DXRayTracingQueryHeap.cpp
@@ -14,7 +14,7 @@ DXRayTracingQueryHeap::DXRayTracingQueryHeap(DXDevice& device, QueryHeapType typ
     auto desc = CD3DX12_RESOURCE_DESC::Buffer(count * sizeof(uint64_t));
     desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     m_device.GetDevice()->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
-                                                  D3D12_HEAP_FLAG_NONE, &desc, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+                                                  D3D12_HEAP_FLAG_NONE, &desc, D3D12_RESOURCE_STATE_COMMON,
                                                   nullptr, IID_PPV_ARGS(&m_resource));
 }
 


### PR DESCRIPTION
Fix this warning when creating the query heap:

```D3D12 WARNING: ID3D12Device::CreateCommittedResource: Ignoring InitialState D3D12_RESOURCE_STATE_UNORDERED_ACCESS. Buffers are effectively created in state D3D12_RESOURCE_STATE_COMMON. [ STATE_CREATION WARNING #1328: CREATERESOURCE_STATE_IGNORED]```