### PR TITLE
Binding constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ std::shared_ptr<Adapter> adapter = std::move(instance->EnumerateAdapters()[setti
 std::shared_ptr<Device> device = adapter->CreateDevice();
 std::shared_ptr<CommandQueue> command_queue = device->GetCommandQueue(CommandListType::kGraphics);
 std::shared_ptr<Swapchain> swapchain =
-    device->CreateSwapchain(app.GetNativeWindow(), app_size.width(), app_size.height(), kFrameCount, settings.vsync);
+    device->CreateSwapchain(app.GetNativeSurface(), app_size.width(), app_size.height(), kFrameCount, settings.vsync);
 uint64_t fence_value = 0;
 std::shared_ptr<Fence> fence = device->CreateFence(fence_value);
 
@@ -71,9 +71,9 @@ BindKey constant_buffer_key = {
     .space = 0,
     .count = 1,
 };
-std::shared_ptr<BindingSetLayout> layout = device->CreateBindingSetLayout({ constant_buffer_key });
+std::shared_ptr<BindingSetLayout> layout = device->CreateBindingSetLayout({ .bind_keys = { constant_buffer_key } });
 std::shared_ptr<BindingSet> binding_set = device->CreateBindingSet(layout);
-binding_set->WriteBindings({ { constant_buffer_key, constant_buffer_view } });
+binding_set->WriteBindings({ .bindings = { { constant_buffer_key, constant_buffer_view } } });
 
 GraphicsPipelineDesc pipeline_desc = {
     .shaders = { vertex_shader, pixel_shader },

--- a/src/Apps/BindlessTriangle/main.cpp
+++ b/src/Apps/BindlessTriangle/main.cpp
@@ -150,8 +150,8 @@ BindlessTriangleRenderer::BindlessTriangleRenderer(const Settings& settings)
     layout_ = device_->CreateBindingSetLayout({ vertex_constant_buffer_key, vertex_structured_buffers_uint_key,
                                                 vertex_structured_buffers_float3_key, pixel_constant_buffer_key });
     binding_set_ = device_->CreateBindingSet(layout_);
-    binding_set_->WriteBindings({ { vertex_constant_buffer_key, vertex_constant_buffer_view_ },
-                                  { pixel_constant_buffer_key, pixel_constant_buffer_view_ } });
+    binding_set_->WriteBindings({ .bindings = { { vertex_constant_buffer_key, vertex_constant_buffer_view_ },
+                                                { pixel_constant_buffer_key, pixel_constant_buffer_view_ } } });
 }
 
 BindlessTriangleRenderer::~BindlessTriangleRenderer()

--- a/src/Apps/BindlessTriangle/main.cpp
+++ b/src/Apps/BindlessTriangle/main.cpp
@@ -147,8 +147,9 @@ BindlessTriangleRenderer::BindlessTriangleRenderer(const Settings& settings)
         .space = 0,
         .count = 1,
     };
-    layout_ = device_->CreateBindingSetLayout({ vertex_constant_buffer_key, vertex_structured_buffers_uint_key,
-                                                vertex_structured_buffers_float3_key, pixel_constant_buffer_key });
+    layout_ = device_->CreateBindingSetLayout(
+        { .bind_keys = { vertex_constant_buffer_key, vertex_structured_buffers_uint_key,
+                         vertex_structured_buffers_float3_key, pixel_constant_buffer_key } });
     binding_set_ = device_->CreateBindingSet(layout_);
     binding_set_->WriteBindings({ .bindings = { { vertex_constant_buffer_key, vertex_constant_buffer_view_ },
                                                 { pixel_constant_buffer_key, pixel_constant_buffer_view_ } } });

--- a/src/Apps/DepthStencilRead/main.cpp
+++ b/src/Apps/DepthStencilRead/main.cpp
@@ -145,8 +145,8 @@ DepthStencilReadRenderer::DepthStencilReadRenderer(const Settings& settings)
     BindKey pixel_constant_buffer_key = pixel_shader_->GetBindKey("constant_buffer");
     BindKey pixel_depth_buffer_key = pixel_shader_->GetBindKey("depth_buffer");
     BindKey pixel_stencil_buffer_key = pixel_shader_->GetBindKey("stencil_buffer");
-    layout_ = device_->CreateBindingSetLayout(
-        { vertex_constant_buffer_key, pixel_constant_buffer_key, pixel_depth_buffer_key, pixel_stencil_buffer_key });
+    layout_ = device_->CreateBindingSetLayout({ .bind_keys = { vertex_constant_buffer_key, pixel_constant_buffer_key,
+                                                               pixel_depth_buffer_key, pixel_stencil_buffer_key } });
 
     depth_stencil_pass_binding_sets_.resize(render_model_.GetMeshCount());
     for (size_t i = 0; i < render_model_.GetMeshCount(); ++i) {

--- a/src/Apps/DepthStencilRead/main.cpp
+++ b/src/Apps/DepthStencilRead/main.cpp
@@ -151,9 +151,8 @@ DepthStencilReadRenderer::DepthStencilReadRenderer(const Settings& settings)
     depth_stencil_pass_binding_sets_.resize(render_model_.GetMeshCount());
     for (size_t i = 0; i < render_model_.GetMeshCount(); ++i) {
         depth_stencil_pass_binding_sets_[i] = device_->CreateBindingSet(layout_);
-        depth_stencil_pass_binding_sets_[i]->WriteBindings({
-            { vertex_constant_buffer_key, depth_stencil_pass_constant_buffer_views_[i] },
-        });
+        depth_stencil_pass_binding_sets_[i]->WriteBindings(
+            { .bindings = { { vertex_constant_buffer_key, depth_stencil_pass_constant_buffer_views_[i] } } });
     }
 }
 
@@ -249,12 +248,10 @@ void DepthStencilReadRenderer::Init(const AppSize& app_size, const NativeSurface
     BindKey pixel_stencil_buffer_key = pixel_shader_->GetBindKey("stencil_buffer");
 
     binding_set_ = device_->CreateBindingSet(layout_);
-    binding_set_->WriteBindings({
-        { vertex_constant_buffer_key, vertex_constant_buffer_view_ },
-        { pixel_constant_buffer_key, pixel_constant_buffer_view_ },
-        { pixel_depth_buffer_key, depth_read_view_ },
-        { pixel_stencil_buffer_key, stencil_read_view_ },
-    });
+    binding_set_->WriteBindings({ .bindings = { { vertex_constant_buffer_key, vertex_constant_buffer_view_ },
+                                                { pixel_constant_buffer_key, pixel_constant_buffer_view_ },
+                                                { pixel_depth_buffer_key, depth_read_view_ },
+                                                { pixel_stencil_buffer_key, stencil_read_view_ } } });
 
     for (uint32_t i = 0; i < kFrameCount; ++i) {
         std::shared_ptr<Resource> back_buffer = swapchain_->GetBackBuffer(i);

--- a/src/Apps/DesktopTriangle/main.cpp
+++ b/src/Apps/DesktopTriangle/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char* argv[])
         .space = 0,
         .count = 1,
     };
-    std::shared_ptr<BindingSetLayout> layout = device->CreateBindingSetLayout({ constant_buffer_key });
+    std::shared_ptr<BindingSetLayout> layout = device->CreateBindingSetLayout({ .bind_keys = { constant_buffer_key } });
     std::shared_ptr<BindingSet> binding_set = device->CreateBindingSet(layout);
     binding_set->WriteBindings({ .bindings = { { constant_buffer_key, constant_buffer_view } } });
 

--- a/src/Apps/DesktopTriangle/main.cpp
+++ b/src/Apps/DesktopTriangle/main.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[])
     };
     std::shared_ptr<BindingSetLayout> layout = device->CreateBindingSetLayout({ constant_buffer_key });
     std::shared_ptr<BindingSet> binding_set = device->CreateBindingSet(layout);
-    binding_set->WriteBindings({ { constant_buffer_key, constant_buffer_view } });
+    binding_set->WriteBindings({ .bindings = { { constant_buffer_key, constant_buffer_view } } });
 
     GraphicsPipelineDesc pipeline_desc = {
         .shaders = { vertex_shader, pixel_shader },

--- a/src/Apps/DispatchIndirect/main.cpp
+++ b/src/Apps/DispatchIndirect/main.cpp
@@ -120,8 +120,8 @@ void DispatchIndirectRenderer::Init(const AppSize& app_size, const NativeSurface
     BindKey result_texture_key = compute_shader_->GetBindKey("result_texture");
     for (uint32_t i = 0; i < kFrameCount; ++i) {
         binding_set_[i] = device_->CreateBindingSet(layout_);
-        binding_set_[i]->WriteBindings(
-            { { constant_buffer_key, constant_buffer_views_[i] }, { result_texture_key, result_texture_view_ } });
+        binding_set_[i]->WriteBindings({ .bindings = { { constant_buffer_key, constant_buffer_views_[i] },
+                                                       { result_texture_key, result_texture_view_ } } });
     }
 
     for (uint32_t i = 0; i < kFrameCount; ++i) {

--- a/src/Apps/DispatchIndirect/main.cpp
+++ b/src/Apps/DispatchIndirect/main.cpp
@@ -77,7 +77,7 @@ DispatchIndirectRenderer::DispatchIndirectRenderer(const Settings& settings)
 
     BindKey constant_buffer_key = compute_shader_->GetBindKey("constant_buffer");
     BindKey result_texture_key = compute_shader_->GetBindKey("result_texture");
-    layout_ = device_->CreateBindingSetLayout({ constant_buffer_key, result_texture_key });
+    layout_ = device_->CreateBindingSetLayout({ .bind_keys = { constant_buffer_key, result_texture_key } });
 
     ComputePipelineDesc pipeline_desc = {
         .shader = compute_shader_,

--- a/src/Apps/ModelView/main.cpp
+++ b/src/Apps/ModelView/main.cpp
@@ -130,14 +130,15 @@ void ModelViewRenderer::Init(const AppSize& app_size, const NativeSurface& surfa
     if (device_->IsBindlessSupported()) {
         pixel_bindless_textures_key = pixel_shader_->GetBindKey("bindless_textures");
         pixel_constant_buffer_key = pixel_shader_->GetBindKey("constant_buffer");
-        layout_ = device_->CreateBindingSetLayout(
+        layout_ = device_->CreateBindingSetLayoutWithConstants(
             { pixel_bindless_textures_key, pixel_anisotropic_sampler_key },
             { { vertex_constant_buffer_key, sizeof(glm::mat4) },
               { pixel_constant_buffer_key, sizeof(uint32_t) * render_model_.GetMeshCount() } });
     } else {
         pixel_base_color_texture_key = pixel_shader_->GetBindKey("base_color_texture");
-        layout_ = device_->CreateBindingSetLayout({ pixel_base_color_texture_key, pixel_anisotropic_sampler_key },
-                                                  { { vertex_constant_buffer_key, sizeof(glm::mat4) } });
+        layout_ = device_->CreateBindingSetLayoutWithConstants(
+            { pixel_base_color_texture_key, pixel_anisotropic_sampler_key },
+            { { vertex_constant_buffer_key, sizeof(glm::mat4) } });
     }
 
     glm::mat4 view = GetViewMatrix();

--- a/src/Apps/ModelView/main.cpp
+++ b/src/Apps/ModelView/main.cpp
@@ -155,16 +155,15 @@ void ModelViewRenderer::Init(const AppSize& app_size, const NativeSurface& surfa
             for (size_t i = 0; i < render_model_.GetMeshCount(); ++i) {
                 pixel_constant_data[i] = pixel_textures_views_[i]->GetDescriptorId();
             }
-
-            binding_sets_[i]->WriteBindingsAndConstants(
-                { { pixel_anisotropic_sampler_key, pixel_anisotropic_sampler_view_ } },
-                { { vertex_constant_buffer_key, mvp_span },
-                  { pixel_constant_buffer_key, std::as_bytes(std::span{ pixel_constant_data }) } });
+            binding_sets_[i]->WriteBindings(
+                { .bindings = { { pixel_anisotropic_sampler_key, pixel_anisotropic_sampler_view_ } },
+                  .constants = { { vertex_constant_buffer_key, mvp_span },
+                                 { pixel_constant_buffer_key, std::as_bytes(std::span{ pixel_constant_data }) } } });
         } else {
-            binding_sets_[i]->WriteBindingsAndConstants(
-                { { pixel_anisotropic_sampler_key, pixel_anisotropic_sampler_view_ },
-                  { pixel_base_color_texture_key, pixel_textures_views_[i] } },
-                { { vertex_constant_buffer_key, mvp_span } });
+            binding_sets_[i]->WriteBindings(
+                { .bindings = { { pixel_anisotropic_sampler_key, pixel_anisotropic_sampler_view_ },
+                                { pixel_base_color_texture_key, pixel_textures_views_[i] } },
+                  .constants = { { vertex_constant_buffer_key, mvp_span } } });
         }
     }
 

--- a/src/Apps/ModelView/main.cpp
+++ b/src/Apps/ModelView/main.cpp
@@ -130,15 +130,15 @@ void ModelViewRenderer::Init(const AppSize& app_size, const NativeSurface& surfa
     if (device_->IsBindlessSupported()) {
         pixel_bindless_textures_key = pixel_shader_->GetBindKey("bindless_textures");
         pixel_constant_buffer_key = pixel_shader_->GetBindKey("constant_buffer");
-        layout_ = device_->CreateBindingSetLayoutWithConstants(
-            { pixel_bindless_textures_key, pixel_anisotropic_sampler_key },
-            { { vertex_constant_buffer_key, sizeof(glm::mat4) },
-              { pixel_constant_buffer_key, sizeof(uint32_t) * render_model_.GetMeshCount() } });
+        layout_ = device_->CreateBindingSetLayout(
+            { .bind_keys = { pixel_bindless_textures_key, pixel_anisotropic_sampler_key },
+              .constants = { { vertex_constant_buffer_key, sizeof(glm::mat4) },
+                             { pixel_constant_buffer_key, sizeof(uint32_t) * render_model_.GetMeshCount() } } });
     } else {
         pixel_base_color_texture_key = pixel_shader_->GetBindKey("base_color_texture");
-        layout_ = device_->CreateBindingSetLayoutWithConstants(
-            { pixel_base_color_texture_key, pixel_anisotropic_sampler_key },
-            { { vertex_constant_buffer_key, sizeof(glm::mat4) } });
+        layout_ = device_->CreateBindingSetLayout(
+            { .bind_keys = { pixel_base_color_texture_key, pixel_anisotropic_sampler_key },
+              .constants = { { vertex_constant_buffer_key, sizeof(glm::mat4) } } });
     }
 
     glm::mat4 view = GetViewMatrix();

--- a/src/Apps/RayTracingTriangle/main.cpp
+++ b/src/Apps/RayTracingTriangle/main.cpp
@@ -319,10 +319,8 @@ void RayTracingTriangleRenderer::InitBindingSet()
     BindKey geometry_key = shader->GetBindKey("geometry");
     BindKey result_texture_key = shader->GetBindKey("result_texture");
     binding_set_ = device_->CreateBindingSet(layout_);
-    binding_set_->WriteBindings({
-        { geometry_key, tlas_view_ },
-        { result_texture_key, result_texture_view_ },
-    });
+    binding_set_->WriteBindings(
+        { .bindings = { { geometry_key, tlas_view_ }, { result_texture_key, result_texture_view_ } } });
 }
 
 RayTracingTriangleRenderer::~RayTracingTriangleRenderer()

--- a/src/Apps/RayTracingTriangle/main.cpp
+++ b/src/Apps/RayTracingTriangle/main.cpp
@@ -310,7 +310,7 @@ void RayTracingTriangleRenderer::InitBindingSetLayout()
     const auto& shader = use_ray_tracing_ ? library_ : compute_shader_;
     BindKey geometry_key = shader->GetBindKey("geometry");
     BindKey result_texture_key = shader->GetBindKey("result_texture");
-    layout_ = device_->CreateBindingSetLayout({ geometry_key, result_texture_key });
+    layout_ = device_->CreateBindingSetLayout({ .bind_keys = { geometry_key, result_texture_key } });
 }
 
 void RayTracingTriangleRenderer::InitBindingSet()

--- a/src/Apps/Triangle/main.cpp
+++ b/src/Apps/Triangle/main.cpp
@@ -95,7 +95,7 @@ TriangleRenderer::TriangleRenderer(const Settings& settings)
         .space = 0,
         .count = 1,
     };
-    layout_ = device_->CreateBindingSetLayout({ constant_buffer_key });
+    layout_ = device_->CreateBindingSetLayout({ .bind_keys = { constant_buffer_key } });
     binding_set_ = device_->CreateBindingSet(layout_);
     binding_set_->WriteBindings({ .bindings = { { constant_buffer_key, constant_buffer_view_ } } });
 }

--- a/src/Apps/Triangle/main.cpp
+++ b/src/Apps/Triangle/main.cpp
@@ -97,7 +97,7 @@ TriangleRenderer::TriangleRenderer(const Settings& settings)
     };
     layout_ = device_->CreateBindingSetLayout({ constant_buffer_key });
     binding_set_ = device_->CreateBindingSet(layout_);
-    binding_set_->WriteBindings({ { constant_buffer_key, constant_buffer_view_ } });
+    binding_set_->WriteBindings({ .bindings = { { constant_buffer_key, constant_buffer_view_ } } });
 }
 
 TriangleRenderer::~TriangleRenderer()

--- a/src/FlyCube/BindingSet/BindingSet.h
+++ b/src/FlyCube/BindingSet/BindingSet.h
@@ -2,12 +2,8 @@
 #include "Instance/BaseTypes.h"
 #include "Instance/QueryInterface.h"
 
-#include <vector>
-
 class BindingSet : public QueryInterface {
 public:
     virtual ~BindingSet() = default;
-    virtual void WriteBindings(const std::vector<BindingDesc>& bindings) = 0;
-    virtual void WriteBindingsAndConstants(const std::vector<BindingDesc>& bindings,
-                                           const std::vector<BindingConstantsData>& constants) = 0;
+    virtual void WriteBindings(const WriteBindingsDesc& desc) = 0;
 };

--- a/src/FlyCube/BindingSet/BindingSet.h
+++ b/src/FlyCube/BindingSet/BindingSet.h
@@ -2,7 +2,6 @@
 #include "Instance/BaseTypes.h"
 #include "Instance/QueryInterface.h"
 
-#include <memory>
 #include <vector>
 
 class BindingSet : public QueryInterface {

--- a/src/FlyCube/BindingSet/BindingSet.h
+++ b/src/FlyCube/BindingSet/BindingSet.h
@@ -9,4 +9,6 @@ class BindingSet : public QueryInterface {
 public:
     virtual ~BindingSet() = default;
     virtual void WriteBindings(const std::vector<BindingDesc>& bindings) = 0;
+    virtual void WriteBindingsAndConstants(const std::vector<BindingDesc>& bindings,
+                                           const std::vector<BindingConstantsData>& constants) = 0;
 };

--- a/src/FlyCube/BindingSet/BindingSetBase.cpp
+++ b/src/FlyCube/BindingSet/BindingSetBase.cpp
@@ -1,0 +1,34 @@
+#include "BindingSet/BindingSetBase.h"
+
+#include "Device/Device.h"
+
+void BindingSetBase::CreateConstantsFallbackBuffer(Device& device, const std::vector<BindingConstants>& constants)
+{
+    uint64_t num_bytes = 0;
+    for (const auto& [bind_key, size] : constants) {
+        num_bytes += size;
+    }
+
+    fallback_constants_buffer_ =
+        device.CreateBuffer(MemoryType::kUpload, { .size = num_bytes, .usage = BindFlag::kConstantBuffer });
+
+    num_bytes = 0;
+    for (const auto& [bind_key, size] : constants) {
+        fallback_constants_buffer_offsets_[bind_key] = num_bytes;
+        ViewDesc view_desc = {
+            .view_type = ViewType::kConstantBuffer,
+            .dimension = ViewDimension::kBuffer,
+            .offset = num_bytes,
+        };
+        fallback_constants_buffer_views_[bind_key] = device.CreateView(fallback_constants_buffer_, view_desc);
+        num_bytes += size;
+    }
+}
+
+void BindingSetBase::UpdateConstantsFallbackBuffer(const std::vector<BindingConstantsData>& constants)
+{
+    for (const auto& [bind_key, data] : constants) {
+        fallback_constants_buffer_->UpdateUploadBuffer(fallback_constants_buffer_offsets_.at(bind_key), data.data(),
+                                                       data.size());
+    }
+}

--- a/src/FlyCube/BindingSet/BindingSetBase.cpp
+++ b/src/FlyCube/BindingSet/BindingSetBase.cpp
@@ -24,11 +24,3 @@ void BindingSetBase::CreateConstantsFallbackBuffer(Device& device, const std::ve
         num_bytes += size;
     }
 }
-
-void BindingSetBase::UpdateConstantsFallbackBuffer(const std::vector<BindingConstantsData>& constants)
-{
-    for (const auto& [bind_key, data] : constants) {
-        fallback_constants_buffer_->UpdateUploadBuffer(fallback_constants_buffer_offsets_.at(bind_key), data.data(),
-                                                       data.size());
-    }
-}

--- a/src/FlyCube/BindingSet/BindingSetBase.cpp
+++ b/src/FlyCube/BindingSet/BindingSetBase.cpp
@@ -1,11 +1,14 @@
 #include "BindingSet/BindingSetBase.h"
 
 #include "Device/Device.h"
+#include "Utilities/Common.h"
 
 void BindingSetBase::CreateConstantsFallbackBuffer(Device& device, const std::vector<BindingConstants>& constants)
 {
+    uint64_t alignment = device.GetConstantBufferOffsetAlignment();
     uint64_t num_bytes = 0;
     for (const auto& [bind_key, size] : constants) {
+        num_bytes = Align(num_bytes, alignment);
         num_bytes += size;
     }
 
@@ -14,11 +17,13 @@ void BindingSetBase::CreateConstantsFallbackBuffer(Device& device, const std::ve
 
     num_bytes = 0;
     for (const auto& [bind_key, size] : constants) {
+        num_bytes = Align(num_bytes, alignment);
         fallback_constants_buffer_offsets_[bind_key] = num_bytes;
         ViewDesc view_desc = {
             .view_type = ViewType::kConstantBuffer,
             .dimension = ViewDimension::kBuffer,
             .offset = num_bytes,
+            .buffer_size = size,
         };
         fallback_constants_buffer_views_[bind_key] = device.CreateView(fallback_constants_buffer_, view_desc);
         num_bytes += size;

--- a/src/FlyCube/BindingSet/BindingSetBase.h
+++ b/src/FlyCube/BindingSet/BindingSetBase.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "BindingSet/BindingSet.h"
+
+#include <map>
+#include <memory>
+
+class Device;
+
+class BindingSetBase : public BindingSet {
+protected:
+    void CreateConstantsFallbackBuffer(Device& device, const std::vector<BindingConstants>& constants);
+    void UpdateConstantsFallbackBuffer(const std::vector<BindingConstantsData>& constants);
+
+    std::shared_ptr<Resource> fallback_constants_buffer_;
+    std::map<BindKey, uint64_t> fallback_constants_buffer_offsets_;
+    std::map<BindKey, std::shared_ptr<View>> fallback_constants_buffer_views_;
+};

--- a/src/FlyCube/BindingSet/BindingSetBase.h
+++ b/src/FlyCube/BindingSet/BindingSetBase.h
@@ -9,7 +9,6 @@ class Device;
 class BindingSetBase : public BindingSet {
 protected:
     void CreateConstantsFallbackBuffer(Device& device, const std::vector<BindingConstants>& constants);
-    void UpdateConstantsFallbackBuffer(const std::vector<BindingConstantsData>& constants);
 
     std::shared_ptr<Resource> fallback_constants_buffer_;
     std::map<BindKey, uint64_t> fallback_constants_buffer_offsets_;

--- a/src/FlyCube/BindingSet/DXBindingSet.cpp
+++ b/src/FlyCube/BindingSet/DXBindingSet.cpp
@@ -30,6 +30,11 @@ void DXBindingSet::WriteBindings(const std::vector<BindingDesc>& bindings)
     }
 }
 
+void DXBindingSet::WriteBindingsAndConstants(const std::vector<BindingDesc>& bindings,
+                                             const std::vector<BindingConstantsData>& constants)
+{
+}
+
 void SetRootDescriptorTable(const ComPtr<ID3D12GraphicsCommandList>& command_list,
                             uint32_t root_parameter,
                             bool is_compute,

--- a/src/FlyCube/BindingSet/DXBindingSet.cpp
+++ b/src/FlyCube/BindingSet/DXBindingSet.cpp
@@ -5,18 +5,55 @@
 #include "GPUDescriptorPool/DXGPUDescriptorPoolRange.h"
 #include "View/DXView.h"
 
+namespace {
+
+void SetRootDescriptorTable(const ComPtr<ID3D12GraphicsCommandList>& command_list,
+                            bool is_compute,
+                            uint32_t root_param_index,
+                            D3D12_GPU_DESCRIPTOR_HANDLE base_descriptor)
+{
+    if (is_compute) {
+        command_list->SetComputeRootDescriptorTable(root_param_index, base_descriptor);
+    } else {
+        command_list->SetGraphicsRootDescriptorTable(root_param_index, base_descriptor);
+    }
+}
+
+void SeRoot32BitConstants(const ComPtr<ID3D12GraphicsCommandList>& command_list,
+                          bool is_compute,
+                          uint32_t root_param_index,
+                          const std::span<uint32_t>& data)
+{
+    if (is_compute) {
+        command_list->SetComputeRoot32BitConstants(root_param_index, data.size(), data.data(), 0);
+    } else {
+        command_list->SetGraphicsRoot32BitConstants(root_param_index, data.size(), data.data(), 0);
+    }
+}
+
+} // namespace
+
 DXBindingSet::DXBindingSet(DXDevice& device, const std::shared_ptr<DXBindingSetLayout>& layout)
     : device_(device)
     , layout_(layout)
 {
-    for (const auto& desc : layout_->GetHeapDescs()) {
-        std::shared_ptr<DXGPUDescriptorPoolRange> heap_range = std::make_shared<DXGPUDescriptorPoolRange>(
-            device_.GetGPUDescriptorPool().Allocate(desc.first, desc.second));
-        descriptor_ranges_.emplace(std::piecewise_construct, std::forward_as_tuple(desc.first),
-                                   std::forward_as_tuple(heap_range));
+    for (const auto& [descriptor_type, count] : layout_->GetHeapDescs()) {
+        auto heap_range =
+            std::make_shared<DXGPUDescriptorPoolRange>(device_.GetGPUDescriptorPool().Allocate(descriptor_type, count));
+        descriptor_ranges_.emplace(descriptor_type, heap_range);
     }
 
-    CreateConstantsFallbackBuffer(device_, layout->GetConstants());
+    size_t total_constants = 0;
+    for (const auto& [bind_key, desc] : layout_->GetConstantsLayout()) {
+        constants_data_offsets_[bind_key] = total_constants;
+        total_constants += desc.num_constants;
+    }
+    constants_data_.resize(total_constants);
+
+    CreateConstantsFallbackBuffer(device_, layout->GetFallbackConstants());
+    for (const auto& [bind_key, view] : fallback_constants_buffer_views_) {
+        WriteDescriptor({ bind_key, view });
+    }
 }
 
 void DXBindingSet::WriteBindings(const std::vector<BindingDesc>& bindings)
@@ -27,43 +64,28 @@ void DXBindingSet::WriteBindings(const std::vector<BindingDesc>& bindings)
 void DXBindingSet::WriteBindingsAndConstants(const std::vector<BindingDesc>& bindings,
                                              const std::vector<BindingConstantsData>& constants)
 {
-    auto write_descriptor = [&](const BindingDesc& binding) {
-        decltype(auto) binding_layout = layout_->GetLayout().at(binding.bind_key);
-        std::shared_ptr<DXGPUDescriptorPoolRange> heap_range = descriptor_ranges_.at(binding_layout.heap_type);
-        decltype(auto) src_cpu_handle = binding.view->As<DXView>().GetHandle();
-        heap_range->CopyCpuHandle(binding_layout.heap_offset, src_cpu_handle);
-    };
-
     for (const auto& binding : bindings) {
-        write_descriptor(binding);
+        WriteDescriptor(binding);
     }
 
-    for (const auto& [bind_key, view] : fallback_constants_buffer_views_) {
-        assert(bind_key.count == 1);
-        write_descriptor({ bind_key, view });
-    }
-    UpdateConstantsFallbackBuffer(constants);
-}
-
-void SetRootDescriptorTable(const ComPtr<ID3D12GraphicsCommandList>& command_list,
-                            uint32_t root_parameter,
-                            bool is_compute,
-                            D3D12_GPU_DESCRIPTOR_HANDLE base_descriptor)
-{
-    if (is_compute) {
-        command_list->SetComputeRootDescriptorTable(root_parameter, base_descriptor);
-    } else {
-        command_list->SetGraphicsRootDescriptorTable(root_parameter, base_descriptor);
+    for (const auto& [bind_key, data] : constants) {
+        if (layout_->GetConstantsLayout().contains(bind_key)) {
+            size_t offset = constants_data_offsets_.at(bind_key);
+            memcpy(&constants_data_[offset], data.data(), data.size());
+        } else {
+            fallback_constants_buffer_->UpdateUploadBuffer(fallback_constants_buffer_offsets_.at(bind_key), data.data(),
+                                                           data.size());
+        }
     }
 }
 
 std::vector<ComPtr<ID3D12DescriptorHeap>> DXBindingSet::Apply(const ComPtr<ID3D12GraphicsCommandList>& command_list)
 {
     std::map<D3D12_DESCRIPTOR_HEAP_TYPE, ComPtr<ID3D12DescriptorHeap>> heap_map;
-    for (const auto& table : layout_->GetDescriptorTables()) {
-        D3D12_DESCRIPTOR_HEAP_TYPE heap_type = table.second.heap_type;
+    for (const auto& [_, table] : layout_->GetDescriptorTables()) {
+        D3D12_DESCRIPTOR_HEAP_TYPE heap_type = table.heap_type;
         ComPtr<ID3D12DescriptorHeap> heap;
-        if (table.second.bindless) {
+        if (table.bindless) {
             heap = device_.GetGPUDescriptorPool().GetHeap(heap_type);
         } else {
             heap = descriptor_ranges_.at(heap_type)->GetHeap();
@@ -87,16 +109,31 @@ std::vector<ComPtr<ID3D12DescriptorHeap>> DXBindingSet::Apply(const ComPtr<ID3D1
         command_list->SetDescriptorHeaps(descriptor_heaps_ptr.size(), descriptor_heaps_ptr.data());
     }
 
-    for (const auto& table : layout_->GetDescriptorTables()) {
-        D3D12_DESCRIPTOR_HEAP_TYPE heap_type = table.second.heap_type;
+    for (const auto& [root_param_index, table] : layout_->GetDescriptorTables()) {
+        D3D12_DESCRIPTOR_HEAP_TYPE heap_type = table.heap_type;
         D3D12_GPU_DESCRIPTOR_HANDLE base_descriptor = {};
-        if (table.second.bindless) {
+        if (table.bindless) {
             base_descriptor = device_.GetGPUDescriptorPool().GetHeap(heap_type)->GetGPUDescriptorHandleForHeapStart();
         } else {
-            decltype(auto) heap_range = descriptor_ranges_.at(heap_type);
-            base_descriptor = heap_range->GetGpuHandle(table.second.heap_offset);
+            auto& heap_range = descriptor_ranges_.at(heap_type);
+            base_descriptor = heap_range->GetGpuHandle(table.heap_offset);
         }
-        SetRootDescriptorTable(command_list, table.first, table.second.is_compute, base_descriptor);
+        SetRootDescriptorTable(command_list, table.is_compute, root_param_index, base_descriptor);
     }
+
+    for (const auto& [bind_key, desc] : layout_->GetConstantsLayout()) {
+        size_t offset = constants_data_offsets_.at(bind_key);
+        std::span<uint32_t> data(&constants_data_[offset], desc.num_constants);
+        SeRoot32BitConstants(command_list, desc.is_compute, desc.root_param_index, data);
+    }
+
     return descriptor_heaps;
+}
+
+void DXBindingSet::WriteDescriptor(const BindingDesc& binding)
+{
+    decltype(auto) binding_layout = layout_->GetLayout().at(binding.bind_key);
+    std::shared_ptr<DXGPUDescriptorPoolRange> heap_range = descriptor_ranges_.at(binding_layout.heap_type);
+    decltype(auto) src_cpu_handle = binding.view->As<DXView>().GetHandle();
+    heap_range->CopyCpuHandle(binding_layout.heap_offset, src_cpu_handle);
 }

--- a/src/FlyCube/BindingSet/DXBindingSet.cpp
+++ b/src/FlyCube/BindingSet/DXBindingSet.cpp
@@ -56,19 +56,13 @@ DXBindingSet::DXBindingSet(DXDevice& device, const std::shared_ptr<DXBindingSetL
     }
 }
 
-void DXBindingSet::WriteBindings(const std::vector<BindingDesc>& bindings)
+void DXBindingSet::WriteBindings(const WriteBindingsDesc& desc)
 {
-    WriteBindingsAndConstants(bindings, {});
-}
-
-void DXBindingSet::WriteBindingsAndConstants(const std::vector<BindingDesc>& bindings,
-                                             const std::vector<BindingConstantsData>& constants)
-{
-    for (const auto& binding : bindings) {
+    for (const auto& binding : desc.bindings) {
         WriteDescriptor(binding);
     }
 
-    for (const auto& [bind_key, data] : constants) {
+    for (const auto& [bind_key, data] : desc.constants) {
         if (layout_->GetConstantsLayout().contains(bind_key)) {
             size_t offset = constants_data_offsets_.at(bind_key);
             memcpy(&constants_data_[offset], data.data(), data.size());

--- a/src/FlyCube/BindingSet/DXBindingSet.h
+++ b/src/FlyCube/BindingSet/DXBindingSet.h
@@ -19,9 +19,7 @@ class DXBindingSet : public BindingSetBase {
 public:
     DXBindingSet(DXDevice& device, const std::shared_ptr<DXBindingSetLayout>& layout);
 
-    void WriteBindings(const std::vector<BindingDesc>& bindings) override;
-    void WriteBindingsAndConstants(const std::vector<BindingDesc>& bindings,
-                                   const std::vector<BindingConstantsData>& constants) override;
+    void WriteBindings(const WriteBindingsDesc& desc) override;
 
     std::vector<ComPtr<ID3D12DescriptorHeap>> Apply(const ComPtr<ID3D12GraphicsCommandList>& command_list);
 

--- a/src/FlyCube/BindingSet/DXBindingSet.h
+++ b/src/FlyCube/BindingSet/DXBindingSet.h
@@ -20,6 +20,8 @@ public:
     DXBindingSet(DXDevice& device, const std::shared_ptr<DXBindingSetLayout>& layout);
 
     void WriteBindings(const std::vector<BindingDesc>& bindings) override;
+    void WriteBindingsAndConstants(const std::vector<BindingDesc>& bindings,
+                                   const std::vector<BindingConstantsData>& constants) override;
 
     std::vector<ComPtr<ID3D12DescriptorHeap>> Apply(const ComPtr<ID3D12GraphicsCommandList>& command_list);
 

--- a/src/FlyCube/BindingSet/DXBindingSet.h
+++ b/src/FlyCube/BindingSet/DXBindingSet.h
@@ -26,7 +26,11 @@ public:
     std::vector<ComPtr<ID3D12DescriptorHeap>> Apply(const ComPtr<ID3D12GraphicsCommandList>& command_list);
 
 private:
+    void WriteDescriptor(const BindingDesc& binding);
+
     DXDevice& device_;
     std::shared_ptr<DXBindingSetLayout> layout_;
     std::map<D3D12_DESCRIPTOR_HEAP_TYPE, std::shared_ptr<DXGPUDescriptorPoolRange>> descriptor_ranges_;
+    std::vector<uint32_t> constants_data_;
+    std::map<BindKey, uint64_t> constants_data_offsets_;
 };

--- a/src/FlyCube/BindingSet/DXBindingSet.h
+++ b/src/FlyCube/BindingSet/DXBindingSet.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "BindingSet/BindingSet.h"
+#include "BindingSet/BindingSetBase.h"
 
 #if defined(_WIN32)
 #include <wrl.h>
@@ -15,7 +15,7 @@ class DXDevice;
 class DXBindingSetLayout;
 class DXGPUDescriptorPoolRange;
 
-class DXBindingSet : public BindingSet {
+class DXBindingSet : public BindingSetBase {
 public:
     DXBindingSet(DXDevice& device, const std::shared_ptr<DXBindingSetLayout>& layout);
 

--- a/src/FlyCube/BindingSet/MTBindingSet.h
+++ b/src/FlyCube/BindingSet/MTBindingSet.h
@@ -16,6 +16,8 @@ public:
     MTBindingSet(MTDevice& device, const std::shared_ptr<MTBindingSetLayout>& layout);
 
     void WriteBindings(const std::vector<BindingDesc>& bindings) override;
+    void WriteBindingsAndConstants(const std::vector<BindingDesc>& bindings,
+                                   const std::vector<BindingConstantsData>& constants) override;
 
     void Apply(const std::map<ShaderType, id<MTL4ArgumentTable>>& argument_tables,
                const std::shared_ptr<Pipeline>& state,

--- a/src/FlyCube/BindingSet/MTBindingSet.h
+++ b/src/FlyCube/BindingSet/MTBindingSet.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "BindingSet/BindingSet.h"
+#include "BindingSet/BindingSetBase.h"
 
 #import <Metal/Metal.h>
 
@@ -11,7 +11,7 @@ class MTDevice;
 class MTBindingSetLayout;
 class Pipeline;
 
-class MTBindingSet : public BindingSet {
+class MTBindingSet : public BindingSetBase {
 public:
     MTBindingSet(MTDevice& device, const std::shared_ptr<MTBindingSetLayout>& layout);
 

--- a/src/FlyCube/BindingSet/MTBindingSet.h
+++ b/src/FlyCube/BindingSet/MTBindingSet.h
@@ -15,9 +15,7 @@ class MTBindingSet : public BindingSetBase {
 public:
     MTBindingSet(MTDevice& device, const std::shared_ptr<MTBindingSetLayout>& layout);
 
-    void WriteBindings(const std::vector<BindingDesc>& bindings) override;
-    void WriteBindingsAndConstants(const std::vector<BindingDesc>& bindings,
-                                   const std::vector<BindingConstantsData>& constants) override;
+    void WriteBindings(const WriteBindingsDesc& desc) override;
 
     void Apply(const std::map<ShaderType, id<MTL4ArgumentTable>>& argument_tables,
                const std::shared_ptr<Pipeline>& state,

--- a/src/FlyCube/BindingSet/MTBindingSet.mm
+++ b/src/FlyCube/BindingSet/MTBindingSet.mm
@@ -68,6 +68,9 @@ MTBindingSet::MTBindingSet(MTDevice& device, const std::shared_ptr<MTBindingSetL
     }
 
     CreateConstantsFallbackBuffer(device_, layout->GetConstants());
+    for (const auto& [bind_key, view] : fallback_constants_buffer_views_) {
+        direct_bindings_.insert_or_assign(bind_key, view);
+    }
 }
 
 void MTBindingSet::WriteBindings(const std::vector<BindingDesc>& bindings)
@@ -82,12 +85,10 @@ void MTBindingSet::WriteBindingsAndConstants(const std::vector<BindingDesc>& bin
         assert(bind_key.count != kBindlessCount);
         direct_bindings_.insert_or_assign(bind_key, view);
     }
-
-    for (const auto& [bind_key, view] : fallback_constants_buffer_views_) {
-        assert(bind_key.count == 1);
-        direct_bindings_.insert_or_assign(bind_key, view);
+    for (const auto& [bind_key, data] : constants) {
+        fallback_constants_buffer_->UpdateUploadBuffer(fallback_constants_buffer_offsets_.at(bind_key), data.data(),
+                                                       data.size());
     }
-    UpdateConstantsFallbackBuffer(constants);
 }
 
 void MTBindingSet::Apply(const std::map<ShaderType, id<MTL4ArgumentTable>>& argument_tables,

--- a/src/FlyCube/BindingSet/MTBindingSet.mm
+++ b/src/FlyCube/BindingSet/MTBindingSet.mm
@@ -76,6 +76,11 @@ void MTBindingSet::WriteBindings(const std::vector<BindingDesc>& bindings)
     }
 }
 
+void MTBindingSet::WriteBindingsAndConstants(const std::vector<BindingDesc>& bindings,
+                                             const std::vector<BindingConstantsData>& constants)
+{
+}
+
 void MTBindingSet::Apply(const std::map<ShaderType, id<MTL4ArgumentTable>>& argument_tables,
                          const std::shared_ptr<Pipeline>& state,
                          id<MTLResidencySet> residency_set)

--- a/src/FlyCube/BindingSet/MTBindingSet.mm
+++ b/src/FlyCube/BindingSet/MTBindingSet.mm
@@ -73,19 +73,13 @@ MTBindingSet::MTBindingSet(MTDevice& device, const std::shared_ptr<MTBindingSetL
     }
 }
 
-void MTBindingSet::WriteBindings(const std::vector<BindingDesc>& bindings)
+void MTBindingSet::WriteBindings(const WriteBindingsDesc& desc)
 {
-    WriteBindingsAndConstants(bindings, {});
-}
-
-void MTBindingSet::WriteBindingsAndConstants(const std::vector<BindingDesc>& bindings,
-                                             const std::vector<BindingConstantsData>& constants)
-{
-    for (const auto& [bind_key, view] : bindings) {
+    for (const auto& [bind_key, view] : desc.bindings) {
         assert(bind_key.count != kBindlessCount);
         direct_bindings_.insert_or_assign(bind_key, view);
     }
-    for (const auto& [bind_key, data] : constants) {
+    for (const auto& [bind_key, data] : desc.constants) {
         fallback_constants_buffer_->UpdateUploadBuffer(fallback_constants_buffer_offsets_.at(bind_key), data.data(),
                                                        data.size());
     }

--- a/src/FlyCube/BindingSet/MTBindingSet.mm
+++ b/src/FlyCube/BindingSet/MTBindingSet.mm
@@ -66,19 +66,28 @@ MTBindingSet::MTBindingSet(MTDevice& device, const std::shared_ptr<MTBindingSetL
             bindless_bind_keys_.insert(bind_key);
         }
     }
+
+    CreateConstantsFallbackBuffer(device_, layout->GetConstants());
 }
 
 void MTBindingSet::WriteBindings(const std::vector<BindingDesc>& bindings)
 {
-    for (const auto& [bind_key, view] : bindings) {
-        assert(bind_key.count != kBindlessCount);
-        direct_bindings_.insert_or_assign(bind_key, view);
-    }
+    WriteBindingsAndConstants(bindings, {});
 }
 
 void MTBindingSet::WriteBindingsAndConstants(const std::vector<BindingDesc>& bindings,
                                              const std::vector<BindingConstantsData>& constants)
 {
+    for (const auto& [bind_key, view] : bindings) {
+        assert(bind_key.count != kBindlessCount);
+        direct_bindings_.insert_or_assign(bind_key, view);
+    }
+
+    for (const auto& [bind_key, view] : fallback_constants_buffer_views_) {
+        assert(bind_key.count == 1);
+        direct_bindings_.insert_or_assign(bind_key, view);
+    }
+    UpdateConstantsFallbackBuffer(constants);
 }
 
 void MTBindingSet::Apply(const std::map<ShaderType, id<MTL4ArgumentTable>>& argument_tables,

--- a/src/FlyCube/BindingSet/VKBindingSet.cpp
+++ b/src/FlyCube/BindingSet/VKBindingSet.cpp
@@ -68,6 +68,7 @@ void VKBindingSet::WriteBindingsAndConstants(const std::vector<BindingDesc>& bin
         }
     } else {
         for (const auto& [bind_key, view] : fallback_constants_buffer_views_) {
+            assert(bind_key.count == 1);
             add_descriptor({ bind_key, view });
         }
         UpdateConstantsFallbackBuffer(constants);

--- a/src/FlyCube/BindingSet/VKBindingSet.cpp
+++ b/src/FlyCube/BindingSet/VKBindingSet.cpp
@@ -34,21 +34,15 @@ VKBindingSet::VKBindingSet(VKDevice& device, const std::shared_ptr<VKBindingSetL
     }
 }
 
-void VKBindingSet::WriteBindings(const std::vector<BindingDesc>& bindings)
-{
-    WriteBindingsAndConstants(bindings, {});
-}
-
-void VKBindingSet::WriteBindingsAndConstants(const std::vector<BindingDesc>& bindings,
-                                             const std::vector<BindingConstantsData>& constants)
+void VKBindingSet::WriteBindings(const WriteBindingsDesc& desc)
 {
     std::vector<vk::WriteDescriptorSet> descriptors;
-    for (const auto& binding : bindings) {
+    for (const auto& binding : desc.bindings) {
         WriteDescriptor(descriptors, binding);
     }
 
     std::deque<vk::WriteDescriptorSetInlineUniformBlock> write_descriptor_set_inline_uniform_blocks;
-    for (const auto& [bind_key, data] : constants) {
+    for (const auto& [bind_key, data] : desc.constants) {
         if (layout_->GetInlineUniformBlocks().contains(bind_key)) {
             auto& write_descriptor_set_inline_uniform_block = write_descriptor_set_inline_uniform_blocks.emplace_back();
             write_descriptor_set_inline_uniform_block.dataSize = data.size();

--- a/src/FlyCube/BindingSet/VKBindingSet.h
+++ b/src/FlyCube/BindingSet/VKBindingSet.h
@@ -12,6 +12,9 @@ public:
     VKBindingSet(VKDevice& device, const std::shared_ptr<VKBindingSetLayout>& layout);
 
     void WriteBindings(const std::vector<BindingDesc>& bindings) override;
+    void WriteBindingsAndConstants(const std::vector<BindingDesc>& bindings,
+                                   const std::vector<BindingConstantsData>& constants) override;
+
     const std::vector<vk::DescriptorSet>& GetDescriptorSets() const;
 
 private:

--- a/src/FlyCube/BindingSet/VKBindingSet.h
+++ b/src/FlyCube/BindingSet/VKBindingSet.h
@@ -4,6 +4,10 @@
 
 #include <vulkan/vulkan.hpp>
 
+#include <map>
+#include <memory>
+#include <vector>
+
 class VKDevice;
 class VKBindingSetLayout;
 
@@ -22,4 +26,7 @@ private:
     std::vector<DescriptorSetPool> descriptors_;
     std::vector<vk::DescriptorSet> descriptor_sets_;
     std::shared_ptr<VKBindingSetLayout> layout_;
+    std::shared_ptr<Resource> constants_fallback_buffer_;
+    std::map<BindKey, uint64_t> constants_fallback_buffer_offsets_;
+    std::map<BindKey, std::shared_ptr<View>> constants_fallback_buffer_views_;
 };

--- a/src/FlyCube/BindingSet/VKBindingSet.h
+++ b/src/FlyCube/BindingSet/VKBindingSet.h
@@ -21,6 +21,8 @@ public:
     const std::vector<vk::DescriptorSet>& GetDescriptorSets() const;
 
 private:
+    void WriteDescriptor(std::vector<vk::WriteDescriptorSet>& descriptors, const BindingDesc& binding);
+
     VKDevice& device_;
     std::vector<DescriptorSetPool> descriptors_;
     std::vector<vk::DescriptorSet> descriptor_sets_;

--- a/src/FlyCube/BindingSet/VKBindingSet.h
+++ b/src/FlyCube/BindingSet/VKBindingSet.h
@@ -14,9 +14,7 @@ class VKBindingSet : public BindingSetBase {
 public:
     VKBindingSet(VKDevice& device, const std::shared_ptr<VKBindingSetLayout>& layout);
 
-    void WriteBindings(const std::vector<BindingDesc>& bindings) override;
-    void WriteBindingsAndConstants(const std::vector<BindingDesc>& bindings,
-                                   const std::vector<BindingConstantsData>& constants) override;
+    void WriteBindings(const WriteBindingsDesc& desc) override;
 
     const std::vector<vk::DescriptorSet>& GetDescriptorSets() const;
 

--- a/src/FlyCube/BindingSet/VKBindingSet.h
+++ b/src/FlyCube/BindingSet/VKBindingSet.h
@@ -1,17 +1,16 @@
 #pragma once
-#include "BindingSet/BindingSet.h"
+#include "BindingSet/BindingSetBase.h"
 #include "GPUDescriptorPool/VKGPUDescriptorPool.h"
 
 #include <vulkan/vulkan.hpp>
 
-#include <map>
 #include <memory>
 #include <vector>
 
 class VKDevice;
 class VKBindingSetLayout;
 
-class VKBindingSet : public BindingSet {
+class VKBindingSet : public BindingSetBase {
 public:
     VKBindingSet(VKDevice& device, const std::shared_ptr<VKBindingSetLayout>& layout);
 
@@ -26,7 +25,4 @@ private:
     std::vector<DescriptorSetPool> descriptors_;
     std::vector<vk::DescriptorSet> descriptor_sets_;
     std::shared_ptr<VKBindingSetLayout> layout_;
-    std::shared_ptr<Resource> constants_fallback_buffer_;
-    std::map<BindKey, uint64_t> constants_fallback_buffer_offsets_;
-    std::map<BindKey, std::shared_ptr<View>> constants_fallback_buffer_views_;
 };

--- a/src/FlyCube/BindingSetLayout/BindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/BindingSetLayout.h
@@ -2,9 +2,6 @@
 #include "Instance/BaseTypes.h"
 #include "Instance/QueryInterface.h"
 
-#include <memory>
-#include <vector>
-
 class BindingSetLayout : public QueryInterface {
 public:
     virtual ~BindingSetLayout() = default;

--- a/src/FlyCube/BindingSetLayout/DXBindingSetLayout.cpp
+++ b/src/FlyCube/BindingSetLayout/DXBindingSetLayout.cpp
@@ -73,7 +73,7 @@ D3D12_DESCRIPTOR_HEAP_TYPE GetHeapType(ViewType view_type)
     }
 }
 
-DXBindingSetLayout::DXBindingSetLayout(DXDevice& device, const std::vector<BindKey>& descs)
+DXBindingSetLayout::DXBindingSetLayout(DXDevice& device, const std::vector<BindKey>& bind_keys)
     : device_(device)
 {
     std::vector<D3D12_ROOT_PARAMETER> root_parameters;
@@ -115,7 +115,7 @@ DXBindingSetLayout::DXBindingSetLayout(DXDevice& device, const std::vector<BindK
         }
     };
 
-    for (const auto& bind_key : descs) {
+    for (const auto& bind_key : bind_keys) {
         if (bind_key.count == kBindlessCount) {
             add_bindless_range(bind_key.shader_type, bind_key.view_type, bind_key.slot, bind_key.space);
             continue;

--- a/src/FlyCube/BindingSetLayout/DXBindingSetLayout.cpp
+++ b/src/FlyCube/BindingSetLayout/DXBindingSetLayout.cpp
@@ -73,7 +73,9 @@ D3D12_DESCRIPTOR_HEAP_TYPE GetHeapType(ViewType view_type)
     }
 }
 
-DXBindingSetLayout::DXBindingSetLayout(DXDevice& device, const std::vector<BindKey>& bind_keys)
+DXBindingSetLayout::DXBindingSetLayout(DXDevice& device,
+                                       const std::vector<BindKey>& bind_keys,
+                                       const std::vector<BindingConstants>& constants)
     : device_(device)
 {
     std::vector<D3D12_ROOT_PARAMETER> root_parameters;

--- a/src/FlyCube/BindingSetLayout/DXBindingSetLayout.cpp
+++ b/src/FlyCube/BindingSetLayout/DXBindingSetLayout.cpp
@@ -96,9 +96,7 @@ bool IsCompute(ShaderType shader_type)
 
 } // namespace
 
-DXBindingSetLayout::DXBindingSetLayout(DXDevice& device,
-                                       const std::vector<BindKey>& bind_keys,
-                                       const std::vector<BindingConstants>& constants)
+DXBindingSetLayout::DXBindingSetLayout(DXDevice& device, const BindingSetLayoutDesc& desc)
     : device_(device)
 {
     std::vector<D3D12_ROOT_PARAMETER> root_parameters;
@@ -153,7 +151,7 @@ DXBindingSetLayout::DXBindingSetLayout(DXDevice& device,
         heap_descs_[heap_type] += bind_key.count;
     };
 
-    for (const auto& bind_key : bind_keys) {
+    for (const auto& bind_key : desc.bind_keys) {
         if (bind_key.count == kBindlessCount) {
             add_bindless_range(bind_key.shader_type, bind_key.view_type, bind_key.slot, bind_key.space);
             continue;
@@ -175,7 +173,7 @@ DXBindingSetLayout::DXBindingSetLayout(DXDevice& device,
 
     size_t root_cost = descriptor_table_ranges.size();
     std::map<RootKey, size_t> extra_descriptor_table_ranges;
-    for (const auto& [bind_key, _] : constants) {
+    for (const auto& [bind_key, _] : desc.constants) {
         assert(bind_key.count == 1);
         RootKey root_key = GetRootKey(bind_key);
         if (!descriptor_table_ranges.contains(root_key)) {
@@ -183,7 +181,7 @@ DXBindingSetLayout::DXBindingSetLayout(DXDevice& device,
         }
     }
 
-    for (const auto& [bind_key, size] : constants) {
+    for (const auto& [bind_key, size] : desc.constants) {
         RootKey root_key = GetRootKey(bind_key);
         if (!descriptor_table_ranges.contains(root_key)) {
             if (--extra_descriptor_table_ranges[root_key] == 0) {

--- a/src/FlyCube/BindingSetLayout/DXBindingSetLayout.cpp
+++ b/src/FlyCube/BindingSetLayout/DXBindingSetLayout.cpp
@@ -77,6 +77,7 @@ DXBindingSetLayout::DXBindingSetLayout(DXDevice& device,
                                        const std::vector<BindKey>& bind_keys,
                                        const std::vector<BindingConstants>& constants)
     : device_(device)
+    , constants_(constants)
 {
     std::vector<D3D12_ROOT_PARAMETER> root_parameters;
     using RootKey = std::pair<D3D12_DESCRIPTOR_HEAP_TYPE, ShaderType>;
@@ -191,4 +192,9 @@ const std::map<uint32_t, DescriptorTableDesc>& DXBindingSetLayout::GetDescriptor
 const ComPtr<ID3D12RootSignature>& DXBindingSetLayout::GetRootSignature() const
 {
     return root_signature_;
+}
+
+const std::vector<BindingConstants>& DXBindingSetLayout::GetConstants() const
+{
+    return constants_;
 }

--- a/src/FlyCube/BindingSetLayout/DXBindingSetLayout.cpp
+++ b/src/FlyCube/BindingSetLayout/DXBindingSetLayout.cpp
@@ -191,11 +191,12 @@ DXBindingSetLayout::DXBindingSetLayout(DXDevice& device,
             }
         }
 
-        uint32_t num_constants = (size + 3) / 4;
+        uint64_t num_constants = (size + 3) / 4;
         if (root_cost + num_constants + extra_descriptor_table_ranges.size() <= D3D12_MAX_ROOT_COST) {
             uint32_t root_param_index = add_root_constant(bind_key, num_constants);
             root_cost += num_constants;
-            constants_layout_[bind_key] = { root_param_index, num_constants, IsCompute(bind_key.shader_type) };
+            constants_layout_[bind_key] = { root_param_index, static_cast<uint32_t>(num_constants),
+                                            IsCompute(bind_key.shader_type) };
         } else {
             if (!descriptor_table_ranges.contains(root_key)) {
                 ++root_cost;

--- a/src/FlyCube/BindingSetLayout/DXBindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/DXBindingSetLayout.h
@@ -33,9 +33,7 @@ struct DescriptorTableDesc {
 
 class DXBindingSetLayout : public BindingSetLayout {
 public:
-    DXBindingSetLayout(DXDevice& device,
-                       const std::vector<BindKey>& bind_keys,
-                       const std::vector<BindingConstants>& constants);
+    DXBindingSetLayout(DXDevice& device, const BindingSetLayoutDesc& desc);
 
     const std::map<D3D12_DESCRIPTOR_HEAP_TYPE, size_t>& GetHeapDescs() const;
     const std::map<BindKey, BindingLayoutDesc>& GetLayout() const;

--- a/src/FlyCube/BindingSetLayout/DXBindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/DXBindingSetLayout.h
@@ -13,7 +13,13 @@ using Microsoft::WRL::ComPtr;
 
 class DXDevice;
 
-struct BindingLayout {
+struct ConstantsLayoutDesc {
+    uint32_t root_param_index;
+    uint32_t num_constants;
+    bool is_compute;
+};
+
+struct BindingLayoutDesc {
     D3D12_DESCRIPTOR_HEAP_TYPE heap_type;
     size_t heap_offset;
 };
@@ -32,16 +38,18 @@ public:
                        const std::vector<BindingConstants>& constants);
 
     const std::map<D3D12_DESCRIPTOR_HEAP_TYPE, size_t>& GetHeapDescs() const;
-    const std::map<BindKey, BindingLayout>& GetLayout() const;
+    const std::map<BindKey, BindingLayoutDesc>& GetLayout() const;
     const std::map<uint32_t, DescriptorTableDesc>& GetDescriptorTables() const;
     const ComPtr<ID3D12RootSignature>& GetRootSignature() const;
-    const std::vector<BindingConstants>& GetConstants() const;
+    const std::map<BindKey, ConstantsLayoutDesc>& GetConstantsLayout() const;
+    const std::vector<BindingConstants>& GetFallbackConstants() const;
 
 private:
     DXDevice& device_;
     std::map<D3D12_DESCRIPTOR_HEAP_TYPE, size_t> heap_descs_;
-    std::map<BindKey, BindingLayout> layout_;
+    std::map<BindKey, BindingLayoutDesc> layout_;
     std::map<uint32_t, DescriptorTableDesc> descriptor_tables_;
     ComPtr<ID3D12RootSignature> root_signature_;
-    std::vector<BindingConstants> constants_;
+    std::map<BindKey, ConstantsLayoutDesc> constants_layout_;
+    std::vector<BindingConstants> fallback_constants_;
 };

--- a/src/FlyCube/BindingSetLayout/DXBindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/DXBindingSetLayout.h
@@ -35,6 +35,7 @@ public:
     const std::map<BindKey, BindingLayout>& GetLayout() const;
     const std::map<uint32_t, DescriptorTableDesc>& GetDescriptorTables() const;
     const ComPtr<ID3D12RootSignature>& GetRootSignature() const;
+    const std::vector<BindingConstants>& GetConstants() const;
 
 private:
     DXDevice& device_;
@@ -42,4 +43,5 @@ private:
     std::map<BindKey, BindingLayout> layout_;
     std::map<uint32_t, DescriptorTableDesc> descriptor_tables_;
     ComPtr<ID3D12RootSignature> root_signature_;
+    std::vector<BindingConstants> constants_;
 };

--- a/src/FlyCube/BindingSetLayout/DXBindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/DXBindingSetLayout.h
@@ -27,7 +27,9 @@ struct DescriptorTableDesc {
 
 class DXBindingSetLayout : public BindingSetLayout {
 public:
-    DXBindingSetLayout(DXDevice& device, const std::vector<BindKey>& bind_keys);
+    DXBindingSetLayout(DXDevice& device,
+                       const std::vector<BindKey>& bind_keys,
+                       const std::vector<BindingConstants>& constants);
 
     const std::map<D3D12_DESCRIPTOR_HEAP_TYPE, size_t>& GetHeapDescs() const;
     const std::map<BindKey, BindingLayout>& GetLayout() const;

--- a/src/FlyCube/BindingSetLayout/DXBindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/DXBindingSetLayout.h
@@ -27,7 +27,7 @@ struct DescriptorTableDesc {
 
 class DXBindingSetLayout : public BindingSetLayout {
 public:
-    DXBindingSetLayout(DXDevice& device, const std::vector<BindKey>& descs);
+    DXBindingSetLayout(DXDevice& device, const std::vector<BindKey>& bind_keys);
 
     const std::map<D3D12_DESCRIPTOR_HEAP_TYPE, size_t>& GetHeapDescs() const;
     const std::map<BindKey, BindingLayout>& GetLayout() const;

--- a/src/FlyCube/BindingSetLayout/MTBindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/MTBindingSetLayout.h
@@ -5,11 +5,11 @@ class MTDevice;
 
 class MTBindingSetLayout : public BindingSetLayout {
 public:
-    MTBindingSetLayout(MTDevice& device, const std::vector<BindKey>& descs);
+    MTBindingSetLayout(MTDevice& device, const std::vector<BindKey>& bind_keys);
 
     const std::vector<BindKey>& GetBindKeys() const;
 
 private:
     MTDevice& device_;
-    std::vector<BindKey> descs_;
+    std::vector<BindKey> bind_keys_;
 };

--- a/src/FlyCube/BindingSetLayout/MTBindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/MTBindingSetLayout.h
@@ -5,9 +5,7 @@ class MTDevice;
 
 class MTBindingSetLayout : public BindingSetLayout {
 public:
-    MTBindingSetLayout(MTDevice& device,
-                       const std::vector<BindKey>& bind_keys,
-                       const std::vector<BindingConstants>& constants);
+    MTBindingSetLayout(MTDevice& device, const BindingSetLayoutDesc& desc);
 
     const std::vector<BindKey>& GetBindKeys() const;
     const std::vector<BindingConstants>& GetConstants() const;

--- a/src/FlyCube/BindingSetLayout/MTBindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/MTBindingSetLayout.h
@@ -5,7 +5,9 @@ class MTDevice;
 
 class MTBindingSetLayout : public BindingSetLayout {
 public:
-    MTBindingSetLayout(MTDevice& device, const std::vector<BindKey>& bind_keys);
+    MTBindingSetLayout(MTDevice& device,
+                       const std::vector<BindKey>& bind_keys,
+                       const std::vector<BindingConstants>& constants);
 
     const std::vector<BindKey>& GetBindKeys() const;
 

--- a/src/FlyCube/BindingSetLayout/MTBindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/MTBindingSetLayout.h
@@ -10,8 +10,10 @@ public:
                        const std::vector<BindingConstants>& constants);
 
     const std::vector<BindKey>& GetBindKeys() const;
+    const std::vector<BindingConstants>& GetConstants() const;
 
 private:
     MTDevice& device_;
     std::vector<BindKey> bind_keys_;
+    std::vector<BindingConstants> constants_;
 };

--- a/src/FlyCube/BindingSetLayout/MTBindingSetLayout.mm
+++ b/src/FlyCube/BindingSetLayout/MTBindingSetLayout.mm
@@ -2,12 +2,10 @@
 
 #include "Device/MTDevice.h"
 
-MTBindingSetLayout::MTBindingSetLayout(MTDevice& device,
-                                       const std::vector<BindKey>& bind_keys,
-                                       const std::vector<BindingConstants>& constants)
+MTBindingSetLayout::MTBindingSetLayout(MTDevice& device, const BindingSetLayoutDesc& desc)
     : device_(device)
-    , bind_keys_(bind_keys)
-    , constants_(constants)
+    , bind_keys_(desc.bind_keys)
+    , constants_(desc.constants)
 {
 }
 

--- a/src/FlyCube/BindingSetLayout/MTBindingSetLayout.mm
+++ b/src/FlyCube/BindingSetLayout/MTBindingSetLayout.mm
@@ -7,10 +7,16 @@ MTBindingSetLayout::MTBindingSetLayout(MTDevice& device,
                                        const std::vector<BindingConstants>& constants)
     : device_(device)
     , bind_keys_(bind_keys)
+    , constants_(constants)
 {
 }
 
 const std::vector<BindKey>& MTBindingSetLayout::GetBindKeys() const
 {
     return bind_keys_;
+}
+
+const std::vector<BindingConstants>& MTBindingSetLayout::GetConstants() const
+{
+    return constants_;
 }

--- a/src/FlyCube/BindingSetLayout/MTBindingSetLayout.mm
+++ b/src/FlyCube/BindingSetLayout/MTBindingSetLayout.mm
@@ -2,7 +2,9 @@
 
 #include "Device/MTDevice.h"
 
-MTBindingSetLayout::MTBindingSetLayout(MTDevice& device, const std::vector<BindKey>& bind_keys)
+MTBindingSetLayout::MTBindingSetLayout(MTDevice& device,
+                                       const std::vector<BindKey>& bind_keys,
+                                       const std::vector<BindingConstants>& constants)
     : device_(device)
     , bind_keys_(bind_keys)
 {

--- a/src/FlyCube/BindingSetLayout/MTBindingSetLayout.mm
+++ b/src/FlyCube/BindingSetLayout/MTBindingSetLayout.mm
@@ -2,13 +2,13 @@
 
 #include "Device/MTDevice.h"
 
-MTBindingSetLayout::MTBindingSetLayout(MTDevice& device, const std::vector<BindKey>& descs)
+MTBindingSetLayout::MTBindingSetLayout(MTDevice& device, const std::vector<BindKey>& bind_keys)
     : device_(device)
-    , descs_(descs)
+    , bind_keys_(bind_keys)
 {
 }
 
 const std::vector<BindKey>& MTBindingSetLayout::GetBindKeys() const
 {
-    return descs_;
+    return bind_keys_;
 }

--- a/src/FlyCube/BindingSetLayout/VKBindingSetLayout.cpp
+++ b/src/FlyCube/BindingSetLayout/VKBindingSetLayout.cpp
@@ -53,13 +53,13 @@ vk::ShaderStageFlagBits ShaderType2Bit(ShaderType type)
     }
 }
 
-VKBindingSetLayout::VKBindingSetLayout(VKDevice& device, const std::vector<BindKey>& descs)
+VKBindingSetLayout::VKBindingSetLayout(VKDevice& device, const std::vector<BindKey>& bind_keys)
 {
     std::map<uint32_t, std::vector<vk::DescriptorSetLayoutBinding>> bindings_by_set;
     std::map<uint32_t, std::vector<vk::DescriptorBindingFlags>> bindings_flags_by_set;
     std::map<uint32_t, std::set<uint32_t>> used_bindings_by_set;
 
-    for (const auto& bind_key : descs) {
+    for (const auto& bind_key : bind_keys) {
         assert(!used_bindings_by_set[bind_key.space].contains(bind_key.slot));
         used_bindings_by_set[bind_key.space].insert(bind_key.slot);
 

--- a/src/FlyCube/BindingSetLayout/VKBindingSetLayout.cpp
+++ b/src/FlyCube/BindingSetLayout/VKBindingSetLayout.cpp
@@ -53,15 +53,13 @@ vk::ShaderStageFlagBits ShaderType2Bit(ShaderType type)
     }
 }
 
-VKBindingSetLayout::VKBindingSetLayout(VKDevice& device,
-                                       const std::vector<BindKey>& bind_keys,
-                                       const std::vector<BindingConstants>& constants)
+VKBindingSetLayout::VKBindingSetLayout(VKDevice& device, const BindingSetLayoutDesc& desc)
 {
     std::map<uint32_t, std::vector<vk::DescriptorSetLayoutBinding>> bindings_by_set;
     std::map<uint32_t, std::vector<vk::DescriptorBindingFlags>> bindings_flags_by_set;
     std::map<uint32_t, std::set<uint32_t>> used_bindings_by_set;
 
-    for (const auto& bind_key : bind_keys) {
+    for (const auto& bind_key : desc.bind_keys) {
         assert(!used_bindings_by_set[bind_key.space].contains(bind_key.slot));
         used_bindings_by_set[bind_key.space].insert(bind_key.slot);
 
@@ -86,7 +84,7 @@ VKBindingSetLayout::VKBindingSetLayout(VKDevice& device,
     std::map<ShaderType, uint32_t> inline_uniform_per_stage_blocks;
     uint32_t inline_uniform_blocks = 0;
     InlineUniformBlockProperties inline_uniform_block_properties = device.GetInlineUniformBlockProperties();
-    for (const auto& [bind_key, size] : constants) {
+    for (const auto& [bind_key, size] : desc.constants) {
         assert(bind_key.count == 1);
         assert(!used_bindings_by_set[bind_key.space].contains(bind_key.slot));
         used_bindings_by_set[bind_key.space].insert(bind_key.slot);

--- a/src/FlyCube/BindingSetLayout/VKBindingSetLayout.cpp
+++ b/src/FlyCube/BindingSetLayout/VKBindingSetLayout.cpp
@@ -53,7 +53,9 @@ vk::ShaderStageFlagBits ShaderType2Bit(ShaderType type)
     }
 }
 
-VKBindingSetLayout::VKBindingSetLayout(VKDevice& device, const std::vector<BindKey>& bind_keys)
+VKBindingSetLayout::VKBindingSetLayout(VKDevice& device,
+                                       const std::vector<BindKey>& bind_keys,
+                                       const std::vector<BindingConstants>& constants)
 {
     std::map<uint32_t, std::vector<vk::DescriptorSetLayoutBinding>> bindings_by_set;
     std::map<uint32_t, std::vector<vk::DescriptorBindingFlags>> bindings_flags_by_set;

--- a/src/FlyCube/BindingSetLayout/VKBindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/VKBindingSetLayout.h
@@ -16,9 +16,7 @@ struct AllocateDescriptorSetDesc {
 
 class VKBindingSetLayout : public BindingSetLayout {
 public:
-    VKBindingSetLayout(VKDevice& device,
-                       const std::vector<BindKey>& bind_keys,
-                       const std::vector<BindingConstants>& constants);
+    VKBindingSetLayout(VKDevice& device, const BindingSetLayoutDesc& desc);
 
     const std::map<uint32_t, vk::DescriptorType>& GetBindlessType() const;
     const std::vector<vk::UniqueDescriptorSetLayout>& GetDescriptorSetLayouts() const;

--- a/src/FlyCube/BindingSetLayout/VKBindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/VKBindingSetLayout.h
@@ -5,6 +5,11 @@
 
 class VKDevice;
 
+struct AllocateDescriptorSetDesc {
+    std::map<vk::DescriptorType, size_t> count;
+    size_t inline_uniform_block_bindings = 0;
+};
+
 class VKBindingSetLayout : public BindingSetLayout {
 public:
     VKBindingSetLayout(VKDevice& device,
@@ -13,13 +18,13 @@ public:
 
     const std::map<uint32_t, vk::DescriptorType>& GetBindlessType() const;
     const std::vector<vk::UniqueDescriptorSetLayout>& GetDescriptorSetLayouts() const;
-    const std::vector<std::map<vk::DescriptorType, size_t>>& GetDescriptorCountBySet() const;
+    const std::vector<AllocateDescriptorSetDesc>& GetAllocateDescriptorSetDescs() const;
     vk::PipelineLayout GetPipelineLayout() const;
 
 private:
     std::map<uint32_t, vk::DescriptorType> bindless_type_;
     std::vector<vk::UniqueDescriptorSetLayout> descriptor_set_layouts_;
-    std::vector<std::map<vk::DescriptorType, size_t>> descriptor_count_by_set_;
+    std::vector<AllocateDescriptorSetDesc> allocate_descriptor_set_descs_;
     vk::UniquePipelineLayout pipeline_layout_;
 };
 

--- a/src/FlyCube/BindingSetLayout/VKBindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/VKBindingSetLayout.h
@@ -7,7 +7,9 @@ class VKDevice;
 
 class VKBindingSetLayout : public BindingSetLayout {
 public:
-    VKBindingSetLayout(VKDevice& device, const std::vector<BindKey>& bind_keys);
+    VKBindingSetLayout(VKDevice& device,
+                       const std::vector<BindKey>& bind_keys,
+                       const std::vector<BindingConstants>& constants);
 
     const std::map<uint32_t, vk::DescriptorType>& GetBindlessType() const;
     const std::vector<vk::UniqueDescriptorSetLayout>& GetDescriptorSetLayouts() const;

--- a/src/FlyCube/BindingSetLayout/VKBindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/VKBindingSetLayout.h
@@ -7,7 +7,7 @@ class VKDevice;
 
 class VKBindingSetLayout : public BindingSetLayout {
 public:
-    VKBindingSetLayout(VKDevice& device, const std::vector<BindKey>& descs);
+    VKBindingSetLayout(VKDevice& device, const std::vector<BindKey>& bind_keys);
 
     const std::map<uint32_t, vk::DescriptorType>& GetBindlessType() const;
     const std::vector<vk::UniqueDescriptorSetLayout>& GetDescriptorSetLayouts() const;

--- a/src/FlyCube/BindingSetLayout/VKBindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/VKBindingSetLayout.h
@@ -19,12 +19,14 @@ public:
     const std::map<uint32_t, vk::DescriptorType>& GetBindlessType() const;
     const std::vector<vk::UniqueDescriptorSetLayout>& GetDescriptorSetLayouts() const;
     const std::vector<AllocateDescriptorSetDesc>& GetAllocateDescriptorSetDescs() const;
+    const std::vector<BindingConstants>& GetConstants() const;
     vk::PipelineLayout GetPipelineLayout() const;
 
 private:
     std::map<uint32_t, vk::DescriptorType> bindless_type_;
     std::vector<vk::UniqueDescriptorSetLayout> descriptor_set_layouts_;
     std::vector<AllocateDescriptorSetDesc> allocate_descriptor_set_descs_;
+    std::vector<BindingConstants> constants_;
     vk::UniquePipelineLayout pipeline_layout_;
 };
 

--- a/src/FlyCube/BindingSetLayout/VKBindingSetLayout.h
+++ b/src/FlyCube/BindingSetLayout/VKBindingSetLayout.h
@@ -3,6 +3,10 @@
 
 #include <vulkan/vulkan.hpp>
 
+#include <map>
+#include <set>
+#include <vector>
+
 class VKDevice;
 
 struct AllocateDescriptorSetDesc {
@@ -19,14 +23,16 @@ public:
     const std::map<uint32_t, vk::DescriptorType>& GetBindlessType() const;
     const std::vector<vk::UniqueDescriptorSetLayout>& GetDescriptorSetLayouts() const;
     const std::vector<AllocateDescriptorSetDesc>& GetAllocateDescriptorSetDescs() const;
-    const std::vector<BindingConstants>& GetConstants() const;
+    const std::set<BindKey>& GetInlineUniformBlocks() const;
+    const std::vector<BindingConstants>& GetFallbackConstants() const;
     vk::PipelineLayout GetPipelineLayout() const;
 
 private:
     std::map<uint32_t, vk::DescriptorType> bindless_type_;
     std::vector<vk::UniqueDescriptorSetLayout> descriptor_set_layouts_;
     std::vector<AllocateDescriptorSetDesc> allocate_descriptor_set_descs_;
-    std::vector<BindingConstants> constants_;
+    std::set<BindKey> inline_uniform_blocks_;
+    std::vector<BindingConstants> fallback_constants_;
     vk::UniquePipelineLayout pipeline_layout_;
 };
 

--- a/src/FlyCube/CMakeLists.txt
+++ b/src/FlyCube/CMakeLists.txt
@@ -20,6 +20,8 @@ list(APPEND BindingSet
     $<$<BOOL:${VULKAN_SUPPORT}>:BindingSet/VKBindingSet.cpp>
     $<$<BOOL:${VULKAN_SUPPORT}>:BindingSet/VKBindingSet.h>
     BindingSet/BindingSet.h
+    BindingSet/BindingSetBase.cpp
+    BindingSet/BindingSetBase.h
 )
 
 list(APPEND BindingSetLayout

--- a/src/FlyCube/Device/DXDevice.cpp
+++ b/src/FlyCube/Device/DXDevice.cpp
@@ -329,11 +329,12 @@ std::shared_ptr<View> DXDevice::CreateView(const std::shared_ptr<Resource>& reso
 
 std::shared_ptr<BindingSetLayout> DXDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys)
 {
-    return CreateBindingSetLayout(bind_keys, {});
+    return CreateBindingSetLayoutWithConstants(bind_keys, {});
 }
 
-std::shared_ptr<BindingSetLayout> DXDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys,
-                                                                   const std::vector<BindingConstants>& constants)
+std::shared_ptr<BindingSetLayout> DXDevice::CreateBindingSetLayoutWithConstants(
+    const std::vector<BindKey>& bind_keys,
+    const std::vector<BindingConstants>& constants)
 {
     return std::make_shared<DXBindingSetLayout>(*this, bind_keys, constants);
 }

--- a/src/FlyCube/Device/DXDevice.cpp
+++ b/src/FlyCube/Device/DXDevice.cpp
@@ -329,7 +329,13 @@ std::shared_ptr<View> DXDevice::CreateView(const std::shared_ptr<Resource>& reso
 
 std::shared_ptr<BindingSetLayout> DXDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys)
 {
-    return std::make_shared<DXBindingSetLayout>(*this, bind_keys);
+    return CreateBindingSetLayout(bind_keys, {});
+}
+
+std::shared_ptr<BindingSetLayout> DXDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys,
+                                                                   const std::vector<BindingConstants>& constants)
+{
+    return std::make_shared<DXBindingSetLayout>(*this, bind_keys, constants);
 }
 
 std::shared_ptr<BindingSet> DXDevice::CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout)

--- a/src/FlyCube/Device/DXDevice.cpp
+++ b/src/FlyCube/Device/DXDevice.cpp
@@ -327,16 +327,9 @@ std::shared_ptr<View> DXDevice::CreateView(const std::shared_ptr<Resource>& reso
     return std::make_shared<DXView>(*this, std::static_pointer_cast<DXResource>(resource), view_desc);
 }
 
-std::shared_ptr<BindingSetLayout> DXDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys)
+std::shared_ptr<BindingSetLayout> DXDevice::CreateBindingSetLayout(const BindingSetLayoutDesc& desc)
 {
-    return CreateBindingSetLayoutWithConstants(bind_keys, {});
-}
-
-std::shared_ptr<BindingSetLayout> DXDevice::CreateBindingSetLayoutWithConstants(
-    const std::vector<BindKey>& bind_keys,
-    const std::vector<BindingConstants>& constants)
-{
-    return std::make_shared<DXBindingSetLayout>(*this, bind_keys, constants);
+    return std::make_shared<DXBindingSetLayout>(*this, desc);
 }
 
 std::shared_ptr<BindingSet> DXDevice::CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout)

--- a/src/FlyCube/Device/DXDevice.cpp
+++ b/src/FlyCube/Device/DXDevice.cpp
@@ -499,6 +499,11 @@ ShaderBlobType DXDevice::GetSupportedShaderBlobType() const
     return ShaderBlobType::kDXIL;
 }
 
+uint64_t DXDevice::GetConstantBufferOffsetAlignment() const
+{
+    return D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT;
+}
+
 DXAdapter& DXDevice::GetAdapter()
 {
     return adapter_;

--- a/src/FlyCube/Device/DXDevice.cpp
+++ b/src/FlyCube/Device/DXDevice.cpp
@@ -327,9 +327,9 @@ std::shared_ptr<View> DXDevice::CreateView(const std::shared_ptr<Resource>& reso
     return std::make_shared<DXView>(*this, std::static_pointer_cast<DXResource>(resource), view_desc);
 }
 
-std::shared_ptr<BindingSetLayout> DXDevice::CreateBindingSetLayout(const std::vector<BindKey>& descs)
+std::shared_ptr<BindingSetLayout> DXDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys)
 {
-    return std::make_shared<DXBindingSetLayout>(*this, descs);
+    return std::make_shared<DXBindingSetLayout>(*this, bind_keys);
 }
 
 std::shared_ptr<BindingSet> DXDevice::CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout)

--- a/src/FlyCube/Device/DXDevice.h
+++ b/src/FlyCube/Device/DXDevice.h
@@ -79,6 +79,7 @@ public:
     RaytracingASPrebuildInfo GetTLASPrebuildInfo(uint32_t instance_count,
                                                  BuildAccelerationStructureFlags flags) const override;
     ShaderBlobType GetSupportedShaderBlobType() const override;
+    uint64_t GetConstantBufferOffsetAlignment() const override;
 
     DXAdapter& GetAdapter();
     ComPtr<ID3D12Device> GetDevice();

--- a/src/FlyCube/Device/DXDevice.h
+++ b/src/FlyCube/Device/DXDevice.h
@@ -48,10 +48,7 @@ public:
     std::shared_ptr<Resource> CreateBuffer(MemoryType memory_type, const BufferDesc& desc) override;
     std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) override;
     std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) override;
-    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) override;
-    std::shared_ptr<BindingSetLayout> CreateBindingSetLayoutWithConstants(
-        const std::vector<BindKey>& bind_keys,
-        const std::vector<BindingConstants>& constants) override;
+    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const BindingSetLayoutDesc& desc) override;
     std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) override;
     std::shared_ptr<Shader> CreateShader(const std::vector<uint8_t>& blob,
                                          ShaderBlobType blob_type,

--- a/src/FlyCube/Device/DXDevice.h
+++ b/src/FlyCube/Device/DXDevice.h
@@ -49,8 +49,9 @@ public:
     std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) override;
     std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) override;
     std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) override;
-    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys,
-                                                             const std::vector<BindingConstants>& constants) override;
+    std::shared_ptr<BindingSetLayout> CreateBindingSetLayoutWithConstants(
+        const std::vector<BindKey>& bind_keys,
+        const std::vector<BindingConstants>& constants) override;
     std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) override;
     std::shared_ptr<Shader> CreateShader(const std::vector<uint8_t>& blob,
                                          ShaderBlobType blob_type,

--- a/src/FlyCube/Device/DXDevice.h
+++ b/src/FlyCube/Device/DXDevice.h
@@ -48,7 +48,7 @@ public:
     std::shared_ptr<Resource> CreateBuffer(MemoryType memory_type, const BufferDesc& desc) override;
     std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) override;
     std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) override;
-    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& descs) override;
+    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) override;
     std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) override;
     std::shared_ptr<Shader> CreateShader(const std::vector<uint8_t>& blob,
                                          ShaderBlobType blob_type,

--- a/src/FlyCube/Device/DXDevice.h
+++ b/src/FlyCube/Device/DXDevice.h
@@ -49,6 +49,8 @@ public:
     std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) override;
     std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) override;
     std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) override;
+    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys,
+                                                             const std::vector<BindingConstants>& constants) override;
     std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) override;
     std::shared_ptr<Shader> CreateShader(const std::vector<uint8_t>& blob,
                                          ShaderBlobType blob_type,

--- a/src/FlyCube/Device/Device.h
+++ b/src/FlyCube/Device/Device.h
@@ -49,6 +49,9 @@ public:
     virtual std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) = 0;
     virtual std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) = 0;
     virtual std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) = 0;
+    virtual std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(
+        const std::vector<BindKey>& bind_keys,
+        const std::vector<BindingConstants>& constants) = 0;
     virtual std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) = 0;
     virtual std::shared_ptr<Shader> CreateShader(const std::vector<uint8_t>& blob,
                                                  ShaderBlobType blob_type,

--- a/src/FlyCube/Device/Device.h
+++ b/src/FlyCube/Device/Device.h
@@ -79,4 +79,5 @@ public:
     virtual RaytracingASPrebuildInfo GetTLASPrebuildInfo(uint32_t instance_count,
                                                          BuildAccelerationStructureFlags flags) const = 0;
     virtual ShaderBlobType GetSupportedShaderBlobType() const = 0;
+    virtual uint64_t GetConstantBufferOffsetAlignment() const = 0;
 };

--- a/src/FlyCube/Device/Device.h
+++ b/src/FlyCube/Device/Device.h
@@ -49,7 +49,7 @@ public:
     virtual std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) = 0;
     virtual std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) = 0;
     virtual std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) = 0;
-    virtual std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(
+    virtual std::shared_ptr<BindingSetLayout> CreateBindingSetLayoutWithConstants(
         const std::vector<BindKey>& bind_keys,
         const std::vector<BindingConstants>& constants) = 0;
     virtual std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) = 0;

--- a/src/FlyCube/Device/Device.h
+++ b/src/FlyCube/Device/Device.h
@@ -48,10 +48,7 @@ public:
     virtual std::shared_ptr<Resource> CreateBuffer(MemoryType memory_type, const BufferDesc& desc) = 0;
     virtual std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) = 0;
     virtual std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) = 0;
-    virtual std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) = 0;
-    virtual std::shared_ptr<BindingSetLayout> CreateBindingSetLayoutWithConstants(
-        const std::vector<BindKey>& bind_keys,
-        const std::vector<BindingConstants>& constants) = 0;
+    virtual std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const BindingSetLayoutDesc& desc) = 0;
     virtual std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) = 0;
     virtual std::shared_ptr<Shader> CreateShader(const std::vector<uint8_t>& blob,
                                                  ShaderBlobType blob_type,

--- a/src/FlyCube/Device/Device.h
+++ b/src/FlyCube/Device/Device.h
@@ -48,7 +48,7 @@ public:
     virtual std::shared_ptr<Resource> CreateBuffer(MemoryType memory_type, const BufferDesc& desc) = 0;
     virtual std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) = 0;
     virtual std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) = 0;
-    virtual std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& descs) = 0;
+    virtual std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) = 0;
     virtual std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) = 0;
     virtual std::shared_ptr<Shader> CreateShader(const std::vector<uint8_t>& blob,
                                                  ShaderBlobType blob_type,

--- a/src/FlyCube/Device/MTDevice.h
+++ b/src/FlyCube/Device/MTDevice.h
@@ -66,6 +66,7 @@ public:
     RaytracingASPrebuildInfo GetTLASPrebuildInfo(uint32_t instance_count,
                                                  BuildAccelerationStructureFlags flags) const override;
     ShaderBlobType GetSupportedShaderBlobType() const override;
+    uint64_t GetConstantBufferOffsetAlignment() const override;
 
     id<MTLDevice> GetDevice() const;
     MTLPixelFormat GetMTLPixelFormat(gli::format format);

--- a/src/FlyCube/Device/MTDevice.h
+++ b/src/FlyCube/Device/MTDevice.h
@@ -36,6 +36,8 @@ public:
     std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) override;
     std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) override;
     std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) override;
+    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys,
+                                                             const std::vector<BindingConstants>& constants) override;
     std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) override;
     std::shared_ptr<Shader> CreateShader(const std::vector<uint8_t>& blob,
                                          ShaderBlobType blob_type,

--- a/src/FlyCube/Device/MTDevice.h
+++ b/src/FlyCube/Device/MTDevice.h
@@ -36,8 +36,9 @@ public:
     std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) override;
     std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) override;
     std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) override;
-    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys,
-                                                             const std::vector<BindingConstants>& constants) override;
+    std::shared_ptr<BindingSetLayout> CreateBindingSetLayoutWithConstants(
+        const std::vector<BindKey>& bind_keys,
+        const std::vector<BindingConstants>& constants) override;
     std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) override;
     std::shared_ptr<Shader> CreateShader(const std::vector<uint8_t>& blob,
                                          ShaderBlobType blob_type,

--- a/src/FlyCube/Device/MTDevice.h
+++ b/src/FlyCube/Device/MTDevice.h
@@ -35,10 +35,7 @@ public:
     std::shared_ptr<Resource> CreateBuffer(MemoryType memory_type, const BufferDesc& desc) override;
     std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) override;
     std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) override;
-    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) override;
-    std::shared_ptr<BindingSetLayout> CreateBindingSetLayoutWithConstants(
-        const std::vector<BindKey>& bind_keys,
-        const std::vector<BindingConstants>& constants) override;
+    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const BindingSetLayoutDesc& desc) override;
     std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) override;
     std::shared_ptr<Shader> CreateShader(const std::vector<uint8_t>& blob,
                                          ShaderBlobType blob_type,

--- a/src/FlyCube/Device/MTDevice.h
+++ b/src/FlyCube/Device/MTDevice.h
@@ -35,7 +35,7 @@ public:
     std::shared_ptr<Resource> CreateBuffer(MemoryType memory_type, const BufferDesc& desc) override;
     std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) override;
     std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) override;
-    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& descs) override;
+    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) override;
     std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) override;
     std::shared_ptr<Shader> CreateShader(const std::vector<uint8_t>& blob,
                                          ShaderBlobType blob_type,

--- a/src/FlyCube/Device/MTDevice.mm
+++ b/src/FlyCube/Device/MTDevice.mm
@@ -133,7 +133,13 @@ std::shared_ptr<View> MTDevice::CreateView(const std::shared_ptr<Resource>& reso
 
 std::shared_ptr<BindingSetLayout> MTDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys)
 {
-    return std::make_shared<MTBindingSetLayout>(*this, bind_keys);
+    return CreateBindingSetLayout(bind_keys, {});
+}
+
+std::shared_ptr<BindingSetLayout> MTDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys,
+                                                                   const std::vector<BindingConstants>& constants)
+{
+    return std::make_shared<MTBindingSetLayout>(*this, bind_keys, constants);
 }
 
 std::shared_ptr<BindingSet> MTDevice::CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout)

--- a/src/FlyCube/Device/MTDevice.mm
+++ b/src/FlyCube/Device/MTDevice.mm
@@ -323,6 +323,11 @@ ShaderBlobType MTDevice::GetSupportedShaderBlobType() const
     return ShaderBlobType::kSPIRV;
 }
 
+uint64_t MTDevice::GetConstantBufferOffsetAlignment() const
+{
+    return 16;
+}
+
 id<MTLDevice> MTDevice::GetDevice() const
 {
     return device_;

--- a/src/FlyCube/Device/MTDevice.mm
+++ b/src/FlyCube/Device/MTDevice.mm
@@ -131,9 +131,9 @@ std::shared_ptr<View> MTDevice::CreateView(const std::shared_ptr<Resource>& reso
     return std::make_shared<MTView>(*this, std::static_pointer_cast<MTResource>(resource), view_desc);
 }
 
-std::shared_ptr<BindingSetLayout> MTDevice::CreateBindingSetLayout(const std::vector<BindKey>& descs)
+std::shared_ptr<BindingSetLayout> MTDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys)
 {
-    return std::make_shared<MTBindingSetLayout>(*this, descs);
+    return std::make_shared<MTBindingSetLayout>(*this, bind_keys);
 }
 
 std::shared_ptr<BindingSet> MTDevice::CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout)

--- a/src/FlyCube/Device/MTDevice.mm
+++ b/src/FlyCube/Device/MTDevice.mm
@@ -133,11 +133,12 @@ std::shared_ptr<View> MTDevice::CreateView(const std::shared_ptr<Resource>& reso
 
 std::shared_ptr<BindingSetLayout> MTDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys)
 {
-    return CreateBindingSetLayout(bind_keys, {});
+    return CreateBindingSetLayoutWithConstants(bind_keys, {});
 }
 
-std::shared_ptr<BindingSetLayout> MTDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys,
-                                                                   const std::vector<BindingConstants>& constants)
+std::shared_ptr<BindingSetLayout> MTDevice::CreateBindingSetLayoutWithConstants(
+    const std::vector<BindKey>& bind_keys,
+    const std::vector<BindingConstants>& constants)
 {
     return std::make_shared<MTBindingSetLayout>(*this, bind_keys, constants);
 }

--- a/src/FlyCube/Device/MTDevice.mm
+++ b/src/FlyCube/Device/MTDevice.mm
@@ -131,16 +131,9 @@ std::shared_ptr<View> MTDevice::CreateView(const std::shared_ptr<Resource>& reso
     return std::make_shared<MTView>(*this, std::static_pointer_cast<MTResource>(resource), view_desc);
 }
 
-std::shared_ptr<BindingSetLayout> MTDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys)
+std::shared_ptr<BindingSetLayout> MTDevice::CreateBindingSetLayout(const BindingSetLayoutDesc& desc)
 {
-    return CreateBindingSetLayoutWithConstants(bind_keys, {});
-}
-
-std::shared_ptr<BindingSetLayout> MTDevice::CreateBindingSetLayoutWithConstants(
-    const std::vector<BindKey>& bind_keys,
-    const std::vector<BindingConstants>& constants)
-{
-    return std::make_shared<MTBindingSetLayout>(*this, bind_keys, constants);
+    return std::make_shared<MTBindingSetLayout>(*this, desc);
 }
 
 std::shared_ptr<BindingSet> MTDevice::CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout)

--- a/src/FlyCube/Device/VKDevice.cpp
+++ b/src/FlyCube/Device/VKDevice.cpp
@@ -280,6 +280,17 @@ VKDevice::VKDevice(VKAdapter& adapter)
 
         inline_uniform_block_supported_ = device_vulkan13_features.inlineUniformBlock;
         add_extension(device_vulkan13_features);
+
+        if (inline_uniform_block_supported_) {
+            auto device_vulkan13_properties = GetProperties2<vk::PhysicalDeviceVulkan13Properties>();
+            inline_uniform_block_properties_.max_total_size = device_vulkan13_properties.maxInlineUniformTotalSize;
+            inline_uniform_block_properties_.max_block_size = device_vulkan13_properties.maxInlineUniformBlockSize;
+            inline_uniform_block_properties_.max_per_stage_blocks =
+                device_vulkan13_properties.maxPerStageDescriptorInlineUniformBlocks;
+            inline_uniform_block_properties_.max_blocks =
+                device_vulkan13_properties.maxDescriptorSetInlineUniformBlocks;
+        }
+
     } else {
         assert(enabled_extension_set.contains(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME));
         assert(GetFeatures2<vk::PhysicalDeviceDynamicRenderingFeaturesKHR>().dynamicRendering);
@@ -292,6 +303,16 @@ VKDevice::VKDevice(VKAdapter& adapter)
 
             inline_uniform_block_supported_ = inline_uniform_block_features.inlineUniformBlock;
             add_extension(inline_uniform_block_features);
+        }
+
+        if (inline_uniform_block_supported_) {
+            auto inline_uniform_block_properties = GetProperties2<vk::PhysicalDeviceInlineUniformBlockProperties>();
+            inline_uniform_block_properties_.max_total_size = std::numeric_limits<uint32_t>::max();
+            inline_uniform_block_properties_.max_block_size = inline_uniform_block_properties.maxInlineUniformBlockSize;
+            inline_uniform_block_properties_.max_per_stage_blocks =
+                inline_uniform_block_properties.maxPerStageDescriptorInlineUniformBlocks;
+            inline_uniform_block_properties_.max_blocks =
+                inline_uniform_block_properties.maxDescriptorSetInlineUniformBlocks;
         }
     }
 
@@ -826,4 +847,9 @@ bool VKDevice::HasBufferDeviceAddress() const
 bool VKDevice::IsInlineUniformBlockSupported() const
 {
     return inline_uniform_block_supported_;
+}
+
+const InlineUniformBlockProperties& VKDevice::GetInlineUniformBlockProperties() const
+{
+    return inline_uniform_block_properties_;
 }

--- a/src/FlyCube/Device/VKDevice.cpp
+++ b/src/FlyCube/Device/VKDevice.cpp
@@ -540,11 +540,12 @@ std::shared_ptr<View> VKDevice::CreateView(const std::shared_ptr<Resource>& reso
 
 std::shared_ptr<BindingSetLayout> VKDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys)
 {
-    return CreateBindingSetLayout(bind_keys, {});
+    return CreateBindingSetLayoutWithConstants(bind_keys, {});
 }
 
-std::shared_ptr<BindingSetLayout> VKDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys,
-                                                                   const std::vector<BindingConstants>& constants)
+std::shared_ptr<BindingSetLayout> VKDevice::CreateBindingSetLayoutWithConstants(
+    const std::vector<BindKey>& bind_keys,
+    const std::vector<BindingConstants>& constants)
 {
     return std::make_shared<VKBindingSetLayout>(*this, bind_keys, constants);
 }

--- a/src/FlyCube/Device/VKDevice.cpp
+++ b/src/FlyCube/Device/VKDevice.cpp
@@ -290,7 +290,6 @@ VKDevice::VKDevice(VKAdapter& adapter)
             inline_uniform_block_properties_.max_blocks =
                 device_vulkan13_properties.maxDescriptorSetInlineUniformBlocks;
         }
-
     } else {
         assert(enabled_extension_set.contains(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME));
         assert(GetFeatures2<vk::PhysicalDeviceDynamicRenderingFeaturesKHR>().dynamicRendering);

--- a/src/FlyCube/Device/VKDevice.cpp
+++ b/src/FlyCube/Device/VKDevice.cpp
@@ -7,7 +7,6 @@
 #include "CommandQueue/VKCommandQueue.h"
 #include "Fence/VKTimelineSemaphore.h"
 #include "HLSLCompiler/Compiler.h"
-#include "Instance/VKInstance.h"
 #include "Memory/VKMemory.h"
 #include "Pipeline/VKComputePipeline.h"
 #include "Pipeline/VKGraphicsPipeline.h"
@@ -17,7 +16,6 @@
 #include "Swapchain/VKSwapchain.h"
 #include "Utilities/Logging.h"
 #include "Utilities/NotReached.h"
-#include "Utilities/VKUtility.h"
 #include "View/VKView.h"
 
 #include <set>
@@ -746,6 +744,11 @@ RaytracingASPrebuildInfo VKDevice::GetTLASPrebuildInfo(uint32_t instance_count,
 ShaderBlobType VKDevice::GetSupportedShaderBlobType() const
 {
     return ShaderBlobType::kSPIRV;
+}
+
+uint64_t VKDevice::GetConstantBufferOffsetAlignment() const
+{
+    return device_properties_.limits.minUniformBufferOffsetAlignment;
 }
 
 VKAdapter& VKDevice::GetAdapter()

--- a/src/FlyCube/Device/VKDevice.cpp
+++ b/src/FlyCube/Device/VKDevice.cpp
@@ -277,6 +277,8 @@ VKDevice::VKDevice(VKAdapter& adapter)
         assert(query_device_vulkan13_features.dynamicRendering);
         device_vulkan13_features.dynamicRendering = true;
         device_vulkan13_features.inlineUniformBlock = query_device_vulkan13_features.inlineUniformBlock;
+
+        inline_uniform_block_supported_ = device_vulkan13_features.inlineUniformBlock;
         add_extension(device_vulkan13_features);
     } else {
         assert(enabled_extension_set.contains(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME));

--- a/src/FlyCube/Device/VKDevice.cpp
+++ b/src/FlyCube/Device/VKDevice.cpp
@@ -516,9 +516,9 @@ std::shared_ptr<View> VKDevice::CreateView(const std::shared_ptr<Resource>& reso
     return std::make_shared<VKView>(*this, std::static_pointer_cast<VKResource>(resource), view_desc);
 }
 
-std::shared_ptr<BindingSetLayout> VKDevice::CreateBindingSetLayout(const std::vector<BindKey>& descs)
+std::shared_ptr<BindingSetLayout> VKDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys)
 {
-    return std::make_shared<VKBindingSetLayout>(*this, descs);
+    return std::make_shared<VKBindingSetLayout>(*this, bind_keys);
 }
 
 std::shared_ptr<BindingSet> VKDevice::CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout)

--- a/src/FlyCube/Device/VKDevice.cpp
+++ b/src/FlyCube/Device/VKDevice.cpp
@@ -536,16 +536,9 @@ std::shared_ptr<View> VKDevice::CreateView(const std::shared_ptr<Resource>& reso
     return std::make_shared<VKView>(*this, std::static_pointer_cast<VKResource>(resource), view_desc);
 }
 
-std::shared_ptr<BindingSetLayout> VKDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys)
+std::shared_ptr<BindingSetLayout> VKDevice::CreateBindingSetLayout(const BindingSetLayoutDesc& desc)
 {
-    return CreateBindingSetLayoutWithConstants(bind_keys, {});
-}
-
-std::shared_ptr<BindingSetLayout> VKDevice::CreateBindingSetLayoutWithConstants(
-    const std::vector<BindKey>& bind_keys,
-    const std::vector<BindingConstants>& constants)
-{
-    return std::make_shared<VKBindingSetLayout>(*this, bind_keys, constants);
+    return std::make_shared<VKBindingSetLayout>(*this, desc);
 }
 
 std::shared_ptr<BindingSet> VKDevice::CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout)

--- a/src/FlyCube/Device/VKDevice.cpp
+++ b/src/FlyCube/Device/VKDevice.cpp
@@ -518,7 +518,13 @@ std::shared_ptr<View> VKDevice::CreateView(const std::shared_ptr<Resource>& reso
 
 std::shared_ptr<BindingSetLayout> VKDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys)
 {
-    return std::make_shared<VKBindingSetLayout>(*this, bind_keys);
+    return CreateBindingSetLayout(bind_keys, {});
+}
+
+std::shared_ptr<BindingSetLayout> VKDevice::CreateBindingSetLayout(const std::vector<BindKey>& bind_keys,
+                                                                   const std::vector<BindingConstants>& constants)
+{
+    return std::make_shared<VKBindingSetLayout>(*this, bind_keys, constants);
 }
 
 std::shared_ptr<BindingSet> VKDevice::CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout)

--- a/src/FlyCube/Device/VKDevice.h
+++ b/src/FlyCube/Device/VKDevice.h
@@ -39,7 +39,7 @@ public:
     std::shared_ptr<Resource> CreateBuffer(MemoryType memory_type, const BufferDesc& desc) override;
     std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) override;
     std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) override;
-    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& descs) override;
+    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) override;
     std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) override;
     std::shared_ptr<Shader> CreateShader(const std::vector<uint8_t>& blob,
                                          ShaderBlobType blob_type,

--- a/src/FlyCube/Device/VKDevice.h
+++ b/src/FlyCube/Device/VKDevice.h
@@ -40,6 +40,8 @@ public:
     std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) override;
     std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) override;
     std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) override;
+    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys,
+                                                             const std::vector<BindingConstants>& constants) override;
     std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) override;
     std::shared_ptr<Shader> CreateShader(const std::vector<uint8_t>& blob,
                                          ShaderBlobType blob_type,

--- a/src/FlyCube/Device/VKDevice.h
+++ b/src/FlyCube/Device/VKDevice.h
@@ -77,6 +77,7 @@ public:
     RaytracingASPrebuildInfo GetTLASPrebuildInfo(uint32_t instance_count,
                                                  BuildAccelerationStructureFlags flags) const override;
     ShaderBlobType GetSupportedShaderBlobType() const override;
+    uint64_t GetConstantBufferOffsetAlignment() const override;
 
     VKAdapter& GetAdapter();
     vk::Device GetDevice();

--- a/src/FlyCube/Device/VKDevice.h
+++ b/src/FlyCube/Device/VKDevice.h
@@ -8,6 +8,13 @@
 class VKAdapter;
 class VKCommandQueue;
 
+struct InlineUniformBlockProperties {
+    uint32_t max_total_size;
+    uint32_t max_block_size;
+    uint32_t max_per_stage_blocks;
+    uint32_t max_blocks;
+};
+
 vk::ImageLayout ConvertState(ResourceState state);
 vk::BuildAccelerationStructureFlagsKHR Convert(BuildAccelerationStructureFlags flags);
 vk::Extent2D ConvertShadingRate(ShadingRate shading_rate);
@@ -16,7 +23,7 @@ std::array<vk::FragmentShadingRateCombinerOpKHR, 2> ConvertShadingRateCombiners(
 
 class VKDevice : public Device {
 public:
-    VKDevice(VKAdapter& adapter);
+    explicit VKDevice(VKAdapter& adapter);
     std::shared_ptr<Memory> AllocateMemory(uint64_t size, MemoryType memory_type, uint32_t memory_type_bits) override;
     std::shared_ptr<CommandQueue> GetCommandQueue(CommandListType type) override;
     uint32_t GetTextureDataPitchAlignment() const override;
@@ -85,6 +92,7 @@ public:
     uint32_t GetMaxDescriptorSetBindings(vk::DescriptorType type) const;
     bool HasBufferDeviceAddress() const;
     bool IsInlineUniformBlockSupported() const;
+    const InlineUniformBlockProperties& GetInlineUniformBlockProperties() const;
 
     template <typename Features>
     Features GetFeatures2() const
@@ -137,5 +145,6 @@ private:
     bool draw_indirect_count_supported_ = false;
     bool has_buffer_device_address_ = false;
     bool inline_uniform_block_supported_ = false;
+    InlineUniformBlockProperties inline_uniform_block_properties_;
     vk::PhysicalDeviceProperties device_properties_ = {};
 };

--- a/src/FlyCube/Device/VKDevice.h
+++ b/src/FlyCube/Device/VKDevice.h
@@ -47,8 +47,9 @@ public:
     std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) override;
     std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) override;
     std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) override;
-    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys,
-                                                             const std::vector<BindingConstants>& constants) override;
+    std::shared_ptr<BindingSetLayout> CreateBindingSetLayoutWithConstants(
+        const std::vector<BindKey>& bind_keys,
+        const std::vector<BindingConstants>& constants) override;
     std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) override;
     std::shared_ptr<Shader> CreateShader(const std::vector<uint8_t>& blob,
                                          ShaderBlobType blob_type,

--- a/src/FlyCube/Device/VKDevice.h
+++ b/src/FlyCube/Device/VKDevice.h
@@ -46,10 +46,7 @@ public:
     std::shared_ptr<Resource> CreateBuffer(MemoryType memory_type, const BufferDesc& desc) override;
     std::shared_ptr<Resource> CreateSampler(const SamplerDesc& desc) override;
     std::shared_ptr<View> CreateView(const std::shared_ptr<Resource>& resource, const ViewDesc& view_desc) override;
-    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const std::vector<BindKey>& bind_keys) override;
-    std::shared_ptr<BindingSetLayout> CreateBindingSetLayoutWithConstants(
-        const std::vector<BindKey>& bind_keys,
-        const std::vector<BindingConstants>& constants) override;
+    std::shared_ptr<BindingSetLayout> CreateBindingSetLayout(const BindingSetLayoutDesc& desc) override;
     std::shared_ptr<BindingSet> CreateBindingSet(const std::shared_ptr<BindingSetLayout>& layout) override;
     std::shared_ptr<Shader> CreateShader(const std::vector<uint8_t>& blob,
                                          ShaderBlobType blob_type,

--- a/src/FlyCube/Device/VKDevice.h
+++ b/src/FlyCube/Device/VKDevice.h
@@ -82,6 +82,7 @@ public:
 
     uint32_t GetMaxDescriptorSetBindings(vk::DescriptorType type) const;
     bool HasBufferDeviceAddress() const;
+    bool IsInlineUniformBlockSupported() const;
 
     template <typename Features>
     Features GetFeatures2() const
@@ -133,5 +134,6 @@ private:
     bool bindless_supported_ = false;
     bool draw_indirect_count_supported_ = false;
     bool has_buffer_device_address_ = false;
+    bool inline_uniform_block_supported_ = false;
     vk::PhysicalDeviceProperties device_properties_ = {};
 };

--- a/src/FlyCube/GPUDescriptorPool/VKGPUDescriptorPool.h
+++ b/src/FlyCube/GPUDescriptorPool/VKGPUDescriptorPool.h
@@ -1,8 +1,7 @@
 #pragma once
-#include <vulkan/vulkan.hpp>
+#include "BindingSetLayout/VKBindingSetLayout.h"
 
-#include <algorithm>
-#include <map>
+#include <vulkan/vulkan.hpp>
 
 class VKDevice;
 
@@ -13,12 +12,12 @@ struct DescriptorSetPool {
 
 class VKGPUDescriptorPool {
 public:
-    VKGPUDescriptorPool(VKDevice& device);
+    explicit VKGPUDescriptorPool(VKDevice& device);
     DescriptorSetPool AllocateDescriptorSet(const vk::DescriptorSetLayout& set_layout,
-                                            const std::map<vk::DescriptorType, size_t>& count);
+                                            const AllocateDescriptorSetDesc& desc);
 
 private:
-    vk::UniqueDescriptorPool CreateDescriptorPool(const std::map<vk::DescriptorType, size_t>& count);
+    vk::UniqueDescriptorPool CreateDescriptorPool(const AllocateDescriptorSetDesc& desc);
 
     VKDevice& device_;
 };

--- a/src/FlyCube/HLSLCompiler/MSLConverter.cpp
+++ b/src/FlyCube/HLSLCompiler/MSLConverter.cpp
@@ -1,7 +1,7 @@
 #include "HLSLCompiler/MSLConverter.h"
 
-#include "HLSLCompiler/Compiler.h"
 #include "ShaderReflection/SPIRVReflection.h"
+#include "Utilities/Check.h"
 
 #include <spirv_msl.hpp>
 
@@ -26,7 +26,7 @@ std::map<BindKey, uint32_t> ParseBindings(ShaderType shader_type, const spirv_cr
     enumerate_resources(resources.separate_samplers);
     enumerate_resources(resources.atomic_counters);
     enumerate_resources(resources.acceleration_structures);
-    enumerate_resources(resources.push_constant_buffers);
+    CHECK(resources.push_constant_buffers.empty());
     return mapping;
 }
 

--- a/src/FlyCube/Instance/BaseTypes.h
+++ b/src/FlyCube/Instance/BaseTypes.h
@@ -718,3 +718,8 @@ struct BindingConstantsData {
     BindKey bind_key;
     std::span<const std::byte> data;
 };
+
+struct WriteBindingsDesc {
+    std::vector<BindingDesc> bindings;
+    std::vector<BindingConstantsData> constants;
+};

--- a/src/FlyCube/Instance/BaseTypes.h
+++ b/src/FlyCube/Instance/BaseTypes.h
@@ -710,7 +710,7 @@ using NativeSurface = std::variant<Win32Surface, MetalSurface, AndroidSurface, X
 
 struct BindingConstants {
     BindKey bind_key;
-    uint32_t size = 0;
+    uint64_t size = 0;
 };
 
 struct BindingConstantsData {

--- a/src/FlyCube/Instance/BaseTypes.h
+++ b/src/FlyCube/Instance/BaseTypes.h
@@ -714,6 +714,11 @@ struct BindingConstants {
     uint64_t size = 0;
 };
 
+struct BindingSetLayoutDesc {
+    std::vector<BindKey> bind_keys;
+    std::vector<BindingConstants> constants;
+};
+
 struct BindingConstantsData {
     BindKey bind_key;
     std::span<const std::byte> data;

--- a/src/FlyCube/Instance/BaseTypes.h
+++ b/src/FlyCube/Instance/BaseTypes.h
@@ -715,5 +715,5 @@ struct BindingConstants {
 
 struct BindingConstantsData {
     BindKey bind_key;
-    std::span<uint8_t> data;
+    std::span<const uint8_t> data;
 };

--- a/src/FlyCube/Instance/BaseTypes.h
+++ b/src/FlyCube/Instance/BaseTypes.h
@@ -4,6 +4,7 @@
 #include <gli/format.hpp>
 
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <memory>
 #include <span>
@@ -252,13 +253,13 @@ struct ViewDesc {
     ViewType view_type = ViewType::kUnknown;
     ViewDimension dimension = ViewDimension::kUnknown;
     uint32_t base_mip_level = 0;
-    uint32_t level_count = static_cast<uint32_t>(-1);
+    uint32_t level_count = std::numeric_limits<uint32_t>::max();
     uint32_t base_array_layer = 0;
-    uint32_t layer_count = static_cast<uint32_t>(-1);
+    uint32_t layer_count = std::numeric_limits<uint32_t>::max();
     uint32_t plane_slice = 0;
     uint64_t offset = 0;
     uint32_t structure_stride = 0;
-    uint64_t buffer_size = static_cast<uint64_t>(-1);
+    uint64_t buffer_size = std::numeric_limits<uint64_t>::max();
     gli::format buffer_format = gli::format::FORMAT_UNDEFINED;
     bool bindless = false;
 

--- a/src/FlyCube/Instance/BaseTypes.h
+++ b/src/FlyCube/Instance/BaseTypes.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <span>
 #include <string>
 #include <tuple>
 #include <variant>
@@ -708,6 +709,11 @@ struct WaylandSurface {
 using NativeSurface = std::variant<Win32Surface, MetalSurface, AndroidSurface, XcbSurface, XlibSurface, WaylandSurface>;
 
 struct BindingConstants {
-    BindKey key;
+    BindKey bind_key;
     uint32_t size = 0;
+};
+
+struct BindingConstantsData {
+    BindKey bind_key;
+    std::span<uint8_t> data;
 };

--- a/src/FlyCube/Instance/BaseTypes.h
+++ b/src/FlyCube/Instance/BaseTypes.h
@@ -716,5 +716,5 @@ struct BindingConstants {
 
 struct BindingConstantsData {
     BindKey bind_key;
-    std::span<const uint8_t> data;
+    std::span<const std::byte> data;
 };

--- a/src/FlyCube/Instance/BaseTypes.h
+++ b/src/FlyCube/Instance/BaseTypes.h
@@ -706,3 +706,8 @@ struct WaylandSurface {
 };
 
 using NativeSurface = std::variant<Win32Surface, MetalSurface, AndroidSurface, XcbSurface, XlibSurface, WaylandSurface>;
+
+struct BindingConstants {
+    BindKey key;
+    uint32_t size = 0;
+};

--- a/src/FlyCube/Resource/DXResource.cpp
+++ b/src/FlyCube/Resource/DXResource.cpp
@@ -2,8 +2,8 @@
 
 #include "Device/DXDevice.h"
 #include "Memory/DXMemory.h"
+#include "Utilities/Common.h"
 #include "Utilities/DXGIFormatHelper.h"
-#include "Utilities/SystemUtils.h"
 
 #include <directx/d3dx12.h>
 #include <gli/dx.hpp>
@@ -113,7 +113,7 @@ std::shared_ptr<DXResource> DXResource::CreateBuffer(DXDevice& device, const Buf
     }
 
     if (desc.usage & BindFlag::kConstantBuffer) {
-        buffer_size = (buffer_size + 255) & ~255;
+        buffer_size = Align(buffer_size, device.GetConstantBufferOffsetAlignment());
     }
 
     D3D12_RESOURCE_DESC resource_desc = CD3DX12_RESOURCE_DESC::Buffer(buffer_size);

--- a/src/FlyCube/ShaderReflection/SPIRVReflection.cpp
+++ b/src/FlyCube/ShaderReflection/SPIRVReflection.cpp
@@ -1,5 +1,6 @@
 #include "ShaderReflection/SPIRVReflection.h"
 
+#include "Utilities/Check.h"
 #include "Utilities/Common.h"
 #include "Utilities/NotReached.h"
 
@@ -348,7 +349,7 @@ void ParseBindings(const spirv_cross::CompilerHLSL& compiler,
     enumerate_resources(resources.separate_samplers);
     enumerate_resources(resources.atomic_counters);
     enumerate_resources(resources.acceleration_structures);
-    enumerate_resources(resources.push_constant_buffers);
+    CHECK(resources.push_constant_buffers.empty());
 }
 
 } // namespace

--- a/src/FlyCube/Utilities/Common.cpp
+++ b/src/FlyCube/Utilities/Common.cpp
@@ -1,6 +1,9 @@
 #include "Utilities/Common.h"
 
+#include <cassert>
+
 uint64_t Align(uint64_t size, uint64_t alignment)
 {
+    assert((alignment & (alignment - 1)) == 0);
     return (size + (alignment - 1)) & ~(alignment - 1);
 }


### PR DESCRIPTION
## HLSL constant buffers

### Vulkan
1) VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
2) VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC
3) VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT (maxInlineUniformTotalSize at least 256 bytes, max*InlineUniformBlocks at least 4)

### DirectX 12
[Root signature limits](https://learn.microsoft.com/en-us/windows/win32/direct3d12/root-signature-limits) is 64 DWORDs
1) D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS and Set\*Root32BitConstants
Cost `Num32BitValues` DWORD each
2) D3D12_ROOT_PARAMETER_TYPE_CBV and Set*RootConstantBufferView
Cost 2 DWORDs each
3) D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE and SetDescriptorHeaps + Set\*RootDescriptorTable
Cost 1 DWORD each regardless of NumDescriptorRanges

### Metal
There used to be set\*Bytes which was the closest to root constants, but Metal 4 does not have set*Bytes anymore. Now, you must use MTL4ArgumentTable::setAddress.

## HLSL constant buffers with [[vk::push_constant]]

### Vulkan
Push constants seem to be the closest to root constants, but in fact they have more differences than similarities.
1) A shader stage cannot have more than one push constant block.
2) Vulkan merges push constant blocks from each stage into single block, so push constant blocks in each shader stage must either have the same layout or use different offsets.
3) vkCmdPushConstants takes stageFlags, but stageFlags must include all stages in that push constant range’s VkPushConstantRange::stageFlags. There seems to be no way to have different push constants data if two stages have the same offset of push constant block.
4) If you want to use shaders with incompatible push constant layout or update push constant per stage, you must specify push constant offsets in HLSL or modify SPIRV blob.
5) maxPushConstantsSize (at least 128 bytes for Vulkan Core, 256 bytes Vulkan 1.4)
6) There is no fallback to buffer binding if push constants size exceeds maxPushConstantsSize.
7) Although it is expected that push constants may improve performance, this is not guaranteed, and looks like it may actually decrease performance on some hardware ([Constant data in Vulkan](https://github.com/KhronosGroup/Vulkan-Samples/blob/main/samples/performance/constant_data/README.adoc), https://github.com/gpuweb/gpuweb/issues/75)

### DirectX 12
DirectXShaderCompiler ignores `[[vk::push_constant]]` when compile to DXIL. In DXIL each constant buffer marked with `[[vk::push_constant]]` has its own RegisterSpace and ShaderRegister, while in SPIRV it has neither DescriptorSet nor Binding.

### Metal
SPIRV-Cross emits Buffer for `[[vk::push_constant]]`.

### Conclusion
Vulkan does not allow to work with `[[vk::push_constant]]` the same way as with constant buffers in DirectX 12 and Metal, and while it is possible to emulate Vulkan style in DirectX 12 and Metal, I do not want to support `[[vk::push_constant]]` in FlyCube since it's way too inflexible.

## Proposal
Keep the limitations of the native API as implementation details, if BindingConstants exceeds such limits it will be placed into upload buffer.
1) DirectX 12
Store as much as possible in D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS, put the rest in upload buffer.
2) Vulkan
Store as much as possible in VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK, put the rest in upload buffer.
3) Metal
Put all constants in upload buffer, since there is no other way to support constants.

## Suggested API
To support `VK_EXT_inline_uniform_block` make BindingConstants part of BindingSetLayout/BindingSet, it also allows storing upload buffer in BindingSet.
```
struct BindingConstants {
    BindKey bind_key;
    uint64_t size = 0;
};

struct BindingSetLayoutDesc {
    std::vector<BindKey> bind_keys;
    std::vector<BindingConstants> constants;
};

std::shared_ptr<BindingSetLayout> DXDevice::CreateBindingSetLayout(const BindingSetLayoutDesc& desc);

struct BindingConstantsData {
    BindKey bind_key;
    std::span<const std::byte> data;
};

struct WriteBindingsDesc {
    std::vector<BindingDesc> bindings;
    std::vector<BindingConstantsData> constants;
};

void BindingSet::WriteBindings(const WriteBindingsDesc& desc);

// No changes to CommandList
```

## Future plans
1) Although the proposed changes make it easier to work with constants, per frame or per draw constants still require separate BindingSet's. To address this, I want to add something similar to `VK_KHR_push_descriptor`.
2) Improve memory management of the implicit upload buffer in BindingSet.
3) Explore the possibility of implicitly patching SPIRV to convert HLSL constant buffers into Vulkan push constants, so that push constants can be used without changing FlyCube API behavior.
